### PR TITLE
Fix #2: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: Packages/WebImagePicker
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build package
+        run: swift build
+
+      - name: Test package
+        run: swift test


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` to run CI on pushes to `main` and pull requests targeting `main`
- run `swift build` and `swift test` in `Packages/WebImagePicker` on `macos-latest`

## Test plan
- `cd Packages/WebImagePicker && swift build`
- `cd Packages/WebImagePicker && swift test`
- Result: both commands pass locally

Closes #2

Made with [Cursor](https://cursor.com)