### PR TITLE
Fix #3: add webView extraction mode for JS-rendered pages

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImageExtractionMode+Extractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImageExtractionMode+Extractor.swift
@@ -6,6 +6,8 @@ extension WebImageExtractionMode {
         switch self {
         case .staticHTML:
             StaticHTMLExtractor()
+        case .webView:
+            WebViewPageImageExtractor()
         }
     }
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -4,6 +4,12 @@ import Foundation
 public enum WebImageExtractionMode: Sendable, Hashable {
     /// Parse the raw HTML response (no JavaScript execution).
     case staticHTML
+
+    /// Load the page in `WKWebView` and collect image URLs after JavaScript runs.
+    ///
+    /// Use this for client-rendered pages where images are injected at runtime.
+    /// This mode has higher memory/runtime cost than `.staticHTML`.
+    case webView
 }
 
 public struct WebImagePickerConfiguration: Sendable, Hashable {

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebViewPageImageExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebViewPageImageExtractor.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+#if canImport(WebKit)
+import WebKit
+#endif
+
+/// Extracts image URLs from a JavaScript-rendered DOM via `WKWebView`.
+public struct WebViewPageImageExtractor: PageImageExtractor {
+    public init() {}
+
+    public func discoverImages(from pageURL: URL, configuration: WebImagePickerConfiguration) async throws -> [DiscoveredImage] {
+        guard let scheme = pageURL.scheme?.lowercased(), configuration.allowedURLSchemes.contains(scheme) else {
+            throw WebImagePickerError.invalidURL
+        }
+
+        #if canImport(WebKit)
+        let rawCandidates = try await loadWithWebKit(
+            from: pageURL,
+            timeout: configuration.requestTimeout,
+            userAgent: configuration.userAgent
+        )
+
+        return Self.normalize(rawCandidates: rawCandidates, pageURL: pageURL, configuration: configuration)
+        #else
+        throw WebImagePickerError.extractionFailed
+        #endif
+    }
+
+    internal static func normalize(
+        rawCandidates: [WebViewRawCandidate],
+        pageURL: URL,
+        configuration: WebImagePickerConfiguration
+    ) -> [DiscoveredImage] {
+        var seen = Set<String>()
+        var images: [DiscoveredImage] = []
+
+        func normalizedURL(from raw: String, kind: WebViewRawCandidate.Kind) -> URL? {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if trimmed.lowercased().hasPrefix("data:") { return nil }
+
+            let resolvedURL: URL?
+            switch kind {
+            case .srcset:
+                resolvedURL = SrcSetParser.bestURL(from: trimmed, baseURL: pageURL)
+            case .url:
+                resolvedURL = URL(string: trimmed, relativeTo: pageURL)?.absoluteURL
+            }
+
+            guard var resolved = resolvedURL else { return nil }
+            guard let scheme = resolved.scheme?.lowercased(), configuration.allowedURLSchemes.contains(scheme) else {
+                return nil
+            }
+
+            if var components = URLComponents(url: resolved, resolvingAgainstBaseURL: false) {
+                components.fragment = nil
+                if let fragmentStripped = components.url {
+                    resolved = fragmentStripped
+                }
+            }
+
+            return resolved
+        }
+
+        for candidate in rawCandidates {
+            guard let url = normalizedURL(from: candidate.value, kind: candidate.kind) else { continue }
+            let key = url.absoluteString
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+
+            let label = candidate.altText?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let cleanedLabel = label?.isEmpty == true ? nil : label
+
+            images.append(DiscoveredImage(sourceURL: url, accessibilityLabel: cleanedLabel))
+        }
+
+        return images
+    }
+}
+
+internal struct WebViewRawCandidate: Equatable, Sendable {
+    internal enum Kind: String, Equatable, Sendable {
+        case url
+        case srcset
+    }
+
+    internal var value: String
+    internal var altText: String?
+    internal var kind: Kind
+}
+
+#if canImport(WebKit)
+@MainActor
+private func loadWithWebKit(from pageURL: URL, timeout: TimeInterval, userAgent: String?) async throws -> [WebViewRawCandidate] {
+    let loader = WebViewDOMLoader()
+    return try await loader.loadAndCollect(from: pageURL, timeout: timeout, userAgent: userAgent)
+}
+
+@MainActor
+private final class WebViewDOMLoader: NSObject {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var webView: WKWebView?
+
+    func loadAndCollect(from pageURL: URL, timeout: TimeInterval, userAgent: String?) async throws -> [WebViewRawCandidate] {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        webView.customUserAgent = userAgent
+        self.webView = webView
+
+        let request = URLRequest(
+            url: pageURL,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+            timeoutInterval: timeout
+        )
+        webView.load(request)
+
+        try await waitForNavigation(timeout: timeout)
+
+        // Allow one runloop turn for post-load DOM updates.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        return try await evaluateCandidates(in: webView)
+    }
+
+    private func waitForNavigation(timeout: TimeInterval) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(max(1, timeout) * 1_000_000_000))
+                guard let self else { return }
+                guard let continuation = self.continuation else { return }
+                self.continuation = nil
+                continuation.resume(throwing: WebImagePickerError.extractionFailed)
+            }
+        }
+    }
+
+    private func evaluateCandidates(in webView: WKWebView) async throws -> [WebViewRawCandidate] {
+        let script = #"""
+        (() => {
+          const out = [];
+          const push = (value, alt, kind) => {
+            if (typeof value !== 'string') return;
+            out.push({ value, altText: typeof alt === 'string' ? alt : null, kind });
+          };
+
+          document.querySelectorAll('img').forEach((img) => {
+            push(img.currentSrc || img.src || '', img.alt || null, 'url');
+            const srcset = img.getAttribute('srcset');
+            if (srcset) push(srcset, img.alt || null, 'srcset');
+          });
+
+          document.querySelectorAll('picture source[srcset]').forEach((source) => {
+            const srcset = source.getAttribute('srcset');
+            if (srcset) push(srcset, null, 'srcset');
+          });
+
+          document.querySelectorAll('meta[property="og:image"],meta[name="twitter:image"],meta[name="twitter:image:src"]').forEach((meta) => {
+            const content = meta.getAttribute('content');
+            if (content) push(content, null, 'url');
+          });
+
+          return out;
+        })();
+        """#
+
+        let any = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Any, Error>) in
+            webView.evaluateJavaScript(script) { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: result as Any)
+            }
+        }
+
+        guard let items = any as? [[String: Any]] else {
+            throw WebImagePickerError.extractionFailed
+        }
+
+        return items.compactMap { item in
+            guard let value = item["value"] as? String else { return nil }
+            let kindString = item["kind"] as? String ?? WebViewRawCandidate.Kind.url.rawValue
+            let kind = WebViewRawCandidate.Kind(rawValue: kindString) ?? .url
+            let altText = item["altText"] as? String
+            return WebViewRawCandidate(value: value, altText: altText, kind: kind)
+        }
+    }
+}
+
+extension WebViewDOMLoader: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+}
+#endif

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebViewPageImageExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebViewPageImageExtractorTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import WebImagePicker
+
+final class WebViewPageImageExtractorTests: XCTestCase {
+    private let config = WebImagePickerConfiguration(allowedURLSchemes: ["https", "http"])
+
+    func testNormalizeResolvesRelativeAndStripsFragments() {
+        let pageURL = URL(string: "https://example.com/news/post")!
+        let candidates: [WebViewRawCandidate] = [
+            .init(value: "/img/hero.png#section", altText: "Hero", kind: .url),
+        ]
+
+        let results = WebViewPageImageExtractor.normalize(
+            rawCandidates: candidates,
+            pageURL: pageURL,
+            configuration: config
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].sourceURL.absoluteString, "https://example.com/img/hero.png")
+        XCTAssertEqual(results[0].accessibilityLabel, "Hero")
+    }
+
+    func testNormalizePicksLargestSrcSetCandidate() {
+        let pageURL = URL(string: "https://example.com/")!
+        let candidates: [WebViewRawCandidate] = [
+            .init(
+                value: "/a.png 320w, https://cdn.example.com/b.png 1024w",
+                altText: nil,
+                kind: .srcset
+            ),
+        ]
+
+        let results = WebViewPageImageExtractor.normalize(
+            rawCandidates: candidates,
+            pageURL: pageURL,
+            configuration: config
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].sourceURL.absoluteString, "https://cdn.example.com/b.png")
+    }
+
+    func testNormalizeDedupesAndFiltersDisallowedSchemes() {
+        let pageURL = URL(string: "https://example.com/page")!
+        let restrictedConfig = WebImagePickerConfiguration(allowedURLSchemes: ["https"])
+        let candidates: [WebViewRawCandidate] = [
+            .init(value: "https://example.com/a.png", altText: nil, kind: .url),
+            .init(value: "https://example.com/a.png", altText: "Duplicate", kind: .url),
+            .init(value: "ftp://example.com/b.png", altText: nil, kind: .url),
+        ]
+
+        let results = WebViewPageImageExtractor.normalize(
+            rawCandidates: candidates,
+            pageURL: pageURL,
+            configuration: restrictedConfig
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].sourceURL.absoluteString, "https://example.com/a.png")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Use it when you want users to pull images from the web without leaving your app 
 - **Photos-like sheet** — Navigation stack with Cancel, Done (multi-select), and “Change URL” while browsing.
 - **URL entry first** — Text field with URL-friendly keyboard options where supported; loads the page on demand.
 - **Static HTML extraction** — Collects `<img>`, `srcset`, `<picture>` sources, Open Graph, and Twitter card images; resolves relative URLs and deduplicates.
+- **WebView extraction mode** — Optional `WKWebView`-based discovery for JavaScript-rendered pages.
 - **Masonry layout** — Custom SwiftUI `Layout` with staggered columns (column count adapts by platform / size class).
 - **Configurable** — Selection limit, timeouts, size caps, allowed URL schemes, user agent, and extraction mode (extensible for future strategies).
 - **Cross-platform** — iOS, macOS, visionOS, and tvOS (see [Requirements](#requirements)).
@@ -109,7 +110,7 @@ var config = WebImagePickerConfiguration(
     userAgent: nil,
     maximumHTMLDownloadBytes: 2_000_000,
     maximumImageDownloadBytes: 25_000_000,
-    extractionMode: .staticHTML
+    extractionMode: .staticHTML // or .webView for JS-rendered pages
 )
 
 .webImagePicker(isPresented: $showPicker, configuration: config) { selections in
@@ -121,12 +122,17 @@ With **`selectionLimit == 1`**, tapping an image downloads it immediately and co
 
 ## How it works
 
-1. **Fetch** — The active **`PageImageExtractor`** downloads the HTML document (with a byte limit and timeout). Default mode is **`.staticHTML`** (**`StaticHTMLExtractor`**), backed by [SwiftSoup](https://github.com/scinfu/SwiftSoup).
+1. **Fetch** — The active **`PageImageExtractor`** either downloads and parses raw HTML (**`.staticHTML`**, default, using [SwiftSoup](https://github.com/scinfu/SwiftSoup)) or loads the page in **`WKWebView`** (**`.webView`**) before collecting image candidates from the rendered DOM.
 2. **Discover** — Image candidates are parsed from the markup, normalized to absolute URLs, filtered by allowed schemes, and deduplicated.
 3. **Present** — **`AsyncImage`** loads thumbnails in a **`MasonryLayout`**; the user selects one or more items (subject to the limit).
 4. **Deliver** — On Done (or single-tap when limit is 1), selected URLs are downloaded in bounded concurrency into **`WebImageSelection`** values.
 
-**JavaScript-rendered pages** may not expose images in the initial HTML; only server-rendered (or statically embedded) images are found today. The **`PageImageExtractor`** / **`WebImageExtractionMode`** design is intended to allow a future WebKit-based extractor without breaking callers.
+Use **`.staticHTML`** for fastest extraction on server-rendered pages. Use **`.webView`** when content is injected by JavaScript and missing from initial HTML.
+
+`WKWebView` mode considerations:
+- Runs WebKit work on the main actor and can use more memory/CPU than static parsing.
+- Subject to platform sandbox/network policy (for example, App Sandbox outgoing network permission on macOS).
+- Embedded/isolated content (cross-origin iframes, blocked resources, CSP constraints) may still limit what becomes discoverable.
 
 ## Demo app
 


### PR DESCRIPTION
## Summary
- add `WebImageExtractionMode.webView` and route extractor selection to a new `WebViewPageImageExtractor`
- implement `WKWebView`-based DOM image discovery with URL normalization, scheme filtering, and de-duplication
- document `.staticHTML` vs `.webView` usage and add unit tests for webView candidate normalization

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Passed: 9 tests, 0 failures

Closes #3

Made with [Cursor](https://cursor.com)