### PR TITLE
Fix #4: Injectable URLSession for HTML and image downloads

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/HTMLDocumentFetcher.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/HTMLDocumentFetcher.swift
@@ -8,7 +8,7 @@ enum HTMLDocumentFetcher {
             request.setValue(ua, forHTTPHeaderField: "User-Agent")
         }
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await configuration.urlSession.bytes(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
             throw WebImagePickerError.invalidHTTPResponse
         }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService.swift
@@ -8,7 +8,7 @@ enum ImageDownloadService {
             request.setValue(ua, forHTTPHeaderField: "User-Agent")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await configuration.urlSession.data(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
             throw WebImagePickerError.downloadFailed
         }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -36,6 +36,9 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
 
     public var extractionMode: WebImageExtractionMode
 
+    /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
+    public var urlSession: URLSession
+
     public init(
         selectionLimit: Int = 10,
         maximumConcurrentImageLoads: Int = 4,
@@ -44,7 +47,8 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         userAgent: String? = nil,
         maximumHTMLDownloadBytes: Int = 2_000_000,
         maximumImageDownloadBytes: Int = 25_000_000,
-        extractionMode: WebImageExtractionMode = .staticHTML
+        extractionMode: WebImageExtractionMode = .staticHTML,
+        urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
         self.maximumConcurrentImageLoads = max(1, maximumConcurrentImageLoads)
@@ -54,7 +58,30 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.maximumHTMLDownloadBytes = maximumHTMLDownloadBytes
         self.maximumImageDownloadBytes = maximumImageDownloadBytes
         self.extractionMode = extractionMode
+        self.urlSession = urlSession
     }
 
     public static let `default` = WebImagePickerConfiguration()
+
+    public static func == (lhs: WebImagePickerConfiguration, rhs: WebImagePickerConfiguration) -> Bool {
+        lhs.selectionLimit == rhs.selectionLimit
+            && lhs.maximumConcurrentImageLoads == rhs.maximumConcurrentImageLoads
+            && lhs.requestTimeout == rhs.requestTimeout
+            && lhs.allowedURLSchemes == rhs.allowedURLSchemes
+            && lhs.userAgent == rhs.userAgent
+            && lhs.maximumHTMLDownloadBytes == rhs.maximumHTMLDownloadBytes
+            && lhs.maximumImageDownloadBytes == rhs.maximumImageDownloadBytes
+            && lhs.extractionMode == rhs.extractionMode
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(selectionLimit)
+        hasher.combine(maximumConcurrentImageLoads)
+        hasher.combine(requestTimeout)
+        hasher.combine(allowedURLSchemes)
+        hasher.combine(userAgent)
+        hasher.combine(maximumHTMLDownloadBytes)
+        hasher.combine(maximumImageDownloadBytes)
+        hasher.combine(extractionMode)
+    }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/InjectableURLSessionTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/InjectableURLSessionTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import WebImagePicker
+
+private final class StubURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var _handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func setHandler(_ handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?) {
+        lock.lock()
+        defer { lock.unlock() }
+        _handler = handler
+    }
+
+    private static func handlerForRequest() -> ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _handler
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handlerForRequest() else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func urlSessionWithStub() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: configuration)
+}
+
+final class InjectableURLSessionTests: XCTestCase {
+    override func tearDown() {
+        StubURLProtocol.setHandler(nil)
+        super.tearDown()
+    }
+
+    func testHTMLDocumentFetcherUsesInjectableSession() async throws {
+        let pageURL = URL(string: "https://example.com/page")!
+        let html = #"<html><body><img src="/x.png" alt=""></body></html>"#
+        StubURLProtocol.setHandler { request in
+            XCTAssertEqual(request.url, pageURL)
+            let response = HTTPURLResponse(
+                url: pageURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html; charset=utf-8"]
+            )!
+            return (response, Data(html.utf8))
+        }
+
+        var config = WebImagePickerConfiguration(allowedURLSchemes: ["https"])
+        config.urlSession = urlSessionWithStub()
+
+        let result = try await HTMLDocumentFetcher.fetchString(from: pageURL, configuration: config)
+        XCTAssertEqual(result, html)
+    }
+
+    func testImageDownloadServiceUsesInjectableSession() async throws {
+        let imageURL = URL(string: "https://example.com/photo.jpg")!
+        let payload = Data([0xFF, 0xD8, 0xFF, 0xD9])
+        StubURLProtocol.setHandler { request in
+            XCTAssertEqual(request.url, imageURL)
+            let response = HTTPURLResponse(
+                url: imageURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/jpeg"]
+            )!
+            return (response, payload)
+        }
+
+        var config = WebImagePickerConfiguration(allowedURLSchemes: ["https"])
+        config.urlSession = urlSessionWithStub()
+
+        let selection = try await ImageDownloadService.download(from: imageURL, configuration: config)
+        XCTAssertEqual(selection.data, payload)
+        XCTAssertEqual(selection.contentType, "image/jpeg")
+        XCTAssertEqual(selection.sourceURL, imageURL)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `urlSession` to `WebImagePickerConfiguration` (default `URLSession.shared`).
- Route `HTMLDocumentFetcher` and `ImageDownloadService` through the configured session.
- Preserve `Hashable` by comparing/hashing only scalar settings (session is intentionally excluded).
- Add unit tests with `URLProtocol` stubs proving HTML fetch and image download use the injected session.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- All 11 tests passed (0 failures).

Closes #4

Made with [Cursor](https://cursor.com)