### PR TITLE
Fix #5: Prepend https for bare domains in URL field

### DIFF
--- a/AI_INTEGRATION.md
+++ b/AI_INTEGRATION.md
@@ -192,7 +192,8 @@ Platform helpers (import still `WebImagePicker`):
 
 1. **Static HTML only** in v1: images that appear only after JavaScript runs may be **missing**. This is expected for many SPAs.
 2. **HTTPS-only by default:** `http` pages/images are rejected unless `allowedURLSchemes` includes `"http"`.
-3. **Errors** surface as user-visible strings in the picker UI; thrown errors use **`WebImagePickerError`** for programmatic handling in your own wrappers.
+3. **Bare domains in the URL field:** If the user omits a scheme (e.g. `example.com/article`), the picker **prepends a scheme** when possible: **`https://`** first if allowed, then **`http://`**, then other entries in `allowedURLSchemes`. This is **best-effort** (invalid hosts still fail); users should use an explicit `http://` or `https://` when they need a specific scheme.
+4. **Errors** surface as user-visible strings in the picker UI; thrown errors use **`WebImagePickerError`** for programmatic handling in your own wrappers.
 
 ## Verification checklist (agent should confirm)
 

--- a/Packages/WebImagePicker/Sources/WebImagePicker/PageURLNormalization.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/PageURLNormalization.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum PageURLNormalization {
+    enum ResolveResult: Equatable {
+        case success(URL)
+        case disallowedScheme
+        case invalid
+    }
+
+    /// Resolves user-typed page locations into an absolute URL, prefixing a scheme when the user omits one (e.g. `example.com` → `https://example.com`).
+    ///
+    /// Scheme choice follows `allowedURLSchemes` (`https` preferred, then `http`, then other allowed schemes). Protocol-relative URLs (`//host/path`) are resolved the same way.
+    static func resolve(trimmedInput: String, allowedURLSchemes: Set<String>) -> ResolveResult {
+        let trimmed = trimmedInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .invalid }
+
+        let loweredSchemes = Set(allowedURLSchemes.map { $0.lowercased() })
+
+        if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased(), !scheme.isEmpty {
+            return loweredSchemes.contains(scheme) ? .success(url) : .disallowedScheme
+        }
+
+        if trimmed.hasPrefix("//") {
+            return absoluteURL(byPrefixingSchemeToProtocolRelative: trimmed, allowedURLSchemes: loweredSchemes)
+                .map { .success($0) } ?? .invalid
+        }
+
+        guard !trimmed.contains("://") else { return .invalid }
+
+        return absoluteURL(byPrefixingSchemeToBareInput: trimmed, allowedURLSchemes: loweredSchemes)
+            .map { .success($0) } ?? .invalid
+    }
+
+    private static func absoluteURL(byPrefixingSchemeToProtocolRelative path: String, allowedURLSchemes: Set<String>) -> URL? {
+        for scheme in schemePrefixCandidates(for: allowedURLSchemes) {
+            let combined = "\(scheme):" + path
+            if let url = URL(string: combined), let s = url.scheme?.lowercased(), allowedURLSchemes.contains(s) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private static func absoluteURL(byPrefixingSchemeToBareInput path: String, allowedURLSchemes: Set<String>) -> URL? {
+        for scheme in schemePrefixCandidates(for: allowedURLSchemes) {
+            let combined = "\(scheme)://\(path)"
+            if let url = URL(string: combined), let s = url.scheme?.lowercased(), allowedURLSchemes.contains(s) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private static func schemePrefixCandidates(for allowedURLSchemes: Set<String>) -> [String] {
+        var ordered: [String] = []
+        if allowedURLSchemes.contains("https") { ordered.append("https") }
+        if allowedURLSchemes.contains("http") { ordered.append("http") }
+        ordered.append(contentsOf: allowedURLSchemes.subtracting(["https", "http"]).sorted())
+        return ordered
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
@@ -28,12 +28,19 @@ final class WebImagePickerViewModel {
     func loadPage() async {
         errorMessage = nil
         let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let url = URL(string: trimmed), url.scheme != nil else {
-            errorMessage = "Enter a valid URL."
-            return
-        }
-        guard let scheme = url.scheme?.lowercased(), configuration.allowedURLSchemes.contains(scheme) else {
+        let resolution = PageURLNormalization.resolve(
+            trimmedInput: trimmed,
+            allowedURLSchemes: configuration.allowedURLSchemes
+        )
+        let url: URL
+        switch resolution {
+        case .success(let resolved):
+            url = resolved
+        case .disallowedScheme:
             errorMessage = "This URL scheme is not allowed."
+            return
+        case .invalid:
+            errorMessage = "Enter a valid URL."
             return
         }
 

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/PageURLNormalizationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/PageURLNormalizationTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import WebImagePicker
+
+final class PageURLNormalizationTests: XCTestCase {
+    private let httpsOnly: Set<String> = ["https"]
+    private let httpAndHttps: Set<String> = ["https", "http"]
+
+    func testBareHostPrependsHTTPSWhenAllowed() {
+        let result = PageURLNormalization.resolve(trimmedInput: "example.com/news", allowedURLSchemes: httpsOnly)
+        XCTAssertEqual(result, .success(URL(string: "https://example.com/news")!))
+    }
+
+    func testProtocolRelativePrependsHTTPS() {
+        let result = PageURLNormalization.resolve(trimmedInput: "//example.com/a", allowedURLSchemes: httpsOnly)
+        XCTAssertEqual(result, .success(URL(string: "https://example.com/a")!))
+    }
+
+    func testExplicitHTTPSUnchanged() {
+        let result = PageURLNormalization.resolve(
+            trimmedInput: "https://example.com/",
+            allowedURLSchemes: httpsOnly
+        )
+        XCTAssertEqual(result, .success(URL(string: "https://example.com/")!))
+    }
+
+    func testBareHostUsesHTTPWhenOnlyHTTPAllowed() {
+        let result = PageURLNormalization.resolve(trimmedInput: "example.com", allowedURLSchemes: ["http"])
+        XCTAssertEqual(result, .success(URL(string: "http://example.com")!))
+    }
+
+    func testHTTPPreferredAfterHTTPSForBareHostWhenBothAllowed() {
+        let result = PageURLNormalization.resolve(trimmedInput: "example.com", allowedURLSchemes: httpAndHttps)
+        XCTAssertEqual(result, .success(URL(string: "https://example.com")!))
+    }
+
+    func testExplicitHTTPWhenHTTPAllowed() {
+        let result = PageURLNormalization.resolve(
+            trimmedInput: "http://example.com/path",
+            allowedURLSchemes: httpAndHttps
+        )
+        XCTAssertEqual(result, .success(URL(string: "http://example.com/path")!))
+    }
+
+    func testExplicitHTTPDisallowedWhenHTTPSOnly() {
+        let result = PageURLNormalization.resolve(
+            trimmedInput: "http://example.com/",
+            allowedURLSchemes: httpsOnly
+        )
+        XCTAssertEqual(result, .disallowedScheme)
+    }
+
+    func testExplicitFTPDisallowedWhenHTTPSOnly() {
+        let result = PageURLNormalization.resolve(
+            trimmedInput: "ftp://example.com/r",
+            allowedURLSchemes: httpsOnly
+        )
+        XCTAssertEqual(result, .disallowedScheme)
+    }
+
+    func testMalformedWithSchemeFragmentDoesNotPrefix() {
+        let result = PageURLNormalization.resolve(
+            trimmedInput: "https://not a host",
+            allowedURLSchemes: httpsOnly
+        )
+        XCTAssertEqual(result, .invalid)
+    }
+
+    func testEmptyInvalid() {
+        XCTAssertEqual(
+            PageURLNormalization.resolve(trimmedInput: "", allowedURLSchemes: httpsOnly),
+            .invalid
+        )
+        XCTAssertEqual(
+            PageURLNormalization.resolve(trimmedInput: "   ", allowedURLSchemes: httpsOnly),
+            .invalid
+        )
+    }
+
+    func testBareHostInvalidWhenNoSchemesMatchURLParser() {
+        let result = PageURLNormalization.resolve(
+            trimmedInput: "not\nvalid",
+            allowedURLSchemes: httpsOnly
+        )
+        XCTAssertEqual(result, .invalid)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use it when you want users to pull images from the web without leaving your app 
 ## Features
 
 - **Photos-like sheet** — Navigation stack with Cancel, Done (multi-select), and “Change URL” while browsing.
-- **URL entry first** — Text field with URL-friendly keyboard options where supported; loads the page on demand.
+- **URL entry first** — Text field with URL-friendly keyboard options where supported; loads the page on demand. Bare hosts (e.g. `example.com/path`) are **best-effort normalized** by prepending an allowed scheme (`https` preferred, then `http`, then other schemes in `allowedURLSchemes`). Users can still type an explicit `http://` URL when `http` is allowed.
 - **Static HTML extraction** — Collects `<img>`, `srcset`, `<picture>` sources, Open Graph, and Twitter card images; resolves relative URLs and deduplicates.
 - **WebView extraction mode** — Optional `WKWebView`-based discovery for JavaScript-rendered pages.
 - **Masonry layout** — Custom SwiftUI `Layout` with staggered columns (column count adapts by platform / size class).


### PR DESCRIPTION
## Summary
- Add `PageURLNormalization.resolve` to normalize bare hosts and protocol-relative URLs using allowed schemes (`https` first, then `http`, then others).
- Wire `WebImagePickerViewModel.loadPage()` through the resolver; keep distinct errors for invalid input vs disallowed scheme.
- Document best-effort behavior in README and AI_INTEGRATION.
- Add `PageURLNormalizationTests` for heuristics and scheme policy.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- 22 tests, 0 failures.

Closes #5

Made with [Cursor](https://cursor.com)