### PR TITLE
Fix #7: Stable ForEach identity for demo selected images

### DIFF
--- a/SwiftUI Web Image Picker/ContentView.swift
+++ b/SwiftUI Web Image Picker/ContentView.swift
@@ -28,8 +28,9 @@ struct ContentView: View {
                         .font(.headline)
                     ScrollView {
                         LazyVStack(alignment: .leading, spacing: 12) {
-                            ForEach(Array(selections.enumerated()), id: \.offset) { index, selection in
-                                selectionRow(selection, index: index)
+                            // `WebImagePicker` completes with at most one row per `sourceURL` (selection is URL-deduped). If that ever changes, use an `Identifiable` wrapper with stable UUIDs instead of `id: \.sourceURL`.
+                            ForEach(selections, id: \.sourceURL) { selection in
+                                selectionRow(selection)
                             }
                         }
                     }
@@ -45,7 +46,7 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    private func selectionRow(_ selection: WebImageSelection, index: Int) -> some View {
+    private func selectionRow(_ selection: WebImageSelection) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(selection.sourceURL.absoluteString)
                 .font(.caption)


### PR DESCRIPTION
## Summary
- Replace `ForEach(..., id: \.offset)` with `ForEach(selections, id: \.sourceURL)` in the demo `ContentView` so list identity stays stable when order or content changes.
- Drop unused `index` from `selectionRow`; note when `UUID`-based ids would be needed if duplicate `sourceURL` rows ever appear.

## Test plan
- `cd Packages/WebImagePicker && swift test` — 23 tests, 0 failures

Closes #7

Made with [Cursor](https://cursor.com)