### PR TITLE
Fix #12: extract CSS background-image URLs in static HTML

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/CSSImageURLExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/CSSImageURLExtractor.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Collects raw URL strings from CSS `url(...)` tokens in inline styles and simple stylesheet text.
+enum CSSImageURLExtractor {
+    /// Every `url(...)` argument in `cssFragment` (e.g. one declaration value or an inline `style` attribute).
+    static func urlArguments(from cssFragment: String) -> [String] {
+        var results: [String] = []
+        var searchStart = cssFragment.startIndex
+        urlScan: while searchStart < cssFragment.endIndex,
+                       let urlOpen = cssFragment[searchStart...].range(of: "url(", options: .caseInsensitive)
+        {
+            var idx = urlOpen.upperBound
+            while idx < cssFragment.endIndex, cssFragment[idx].isWhitespace {
+                idx = cssFragment.index(after: idx)
+            }
+            guard idx < cssFragment.endIndex else { break urlScan }
+
+            let parseResult: (Substring, String.Index)? = {
+                switch cssFragment[idx] {
+                case "\"":
+                    let contentStart = cssFragment.index(after: idx)
+                    guard contentStart < cssFragment.endIndex,
+                          let endQuote = cssFragment[contentStart...].firstIndex(of: "\"")
+                    else { return nil }
+                    var j = cssFragment.index(after: endQuote)
+                    while j < cssFragment.endIndex, cssFragment[j].isWhitespace {
+                        j = cssFragment.index(after: j)
+                    }
+                    guard j < cssFragment.endIndex, cssFragment[j] == ")" else { return nil }
+                    let inner = cssFragment[contentStart..<endQuote]
+                    return (inner, cssFragment.index(after: j))
+                case "'":
+                    let contentStart = cssFragment.index(after: idx)
+                    guard contentStart < cssFragment.endIndex,
+                          let endQuote = cssFragment[contentStart...].firstIndex(of: "'")
+                    else { return nil }
+                    var j = cssFragment.index(after: endQuote)
+                    while j < cssFragment.endIndex, cssFragment[j].isWhitespace {
+                        j = cssFragment.index(after: j)
+                    }
+                    guard j < cssFragment.endIndex, cssFragment[j] == ")" else { return nil }
+                    let inner = cssFragment[contentStart..<endQuote]
+                    return (inner, cssFragment.index(after: j))
+                default:
+                    guard let close = cssFragment[idx...].firstIndex(of: ")") else { return nil }
+                    return (cssFragment[idx..<close], cssFragment.index(after: close))
+                }
+            }()
+
+            guard let (extracted, resumeFrom) = parseResult else {
+                searchStart = cssFragment.index(after: urlOpen.lowerBound)
+                continue urlScan
+            }
+
+            let raw = extracted.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !raw.isEmpty {
+                results.append(raw)
+            }
+            searchStart = resumeFrom
+        }
+        return results
+    }
+
+    /// `url(...)` arguments appearing in `background-image` and `background` declaration values inside stylesheet text.
+    static func urlArgumentsFromBackgroundDeclarations(in stylesheet: String) -> [String] {
+        var collected: [String] = []
+        let patterns = [
+            #"background-image\s*:\s*([^;}{\n]+)"#,
+            #"background\s*:\s*([^;}{\n]+)"#,
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else { continue }
+            let ns = stylesheet as NSString
+            let full = NSRange(location: 0, length: ns.length)
+            regex.enumerateMatches(in: stylesheet, options: [], range: full) { match, _, _ in
+                guard let match, match.numberOfRanges >= 2 else { return }
+                let valueRange = match.range(at: 1)
+                guard valueRange.location != NSNotFound else { return }
+                let value = ns.substring(with: valueRange)
+                collected.append(contentsOf: urlArguments(from: value))
+            }
+        }
+        return collected
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/StaticHTMLExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/StaticHTMLExtractor.swift
@@ -37,6 +37,7 @@ public struct StaticHTMLExtractor: PageImageExtractor {
         func normalizedURL(from raw: String) -> URL? {
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
+            if trimmed.hasPrefix("#") { return nil }
             if trimmed.lowercased().hasPrefix("data:") { return nil }
             guard var resolved = URL(string: trimmed, relativeTo: pageURL)?.absoluteURL else { return nil }
             guard let sch = resolved.scheme?.lowercased(), configuration.allowedURLSchemes.contains(sch) else { return nil }
@@ -91,6 +92,24 @@ public struct StaticHTMLExtractor: PageImageExtractor {
         for element in twitterImages.array() {
             if let content = try? element.attr("content") {
                 append(raw: content, alt: nil)
+            }
+        }
+
+        let inlineStyled = try doc.select("[style]")
+        for element in inlineStyled.array() {
+            if let style = try? element.attr("style"), !style.isEmpty {
+                for raw in CSSImageURLExtractor.urlArguments(from: style) {
+                    append(raw: raw, alt: nil)
+                }
+            }
+        }
+
+        let styleBlocks = try doc.select("style")
+        for element in styleBlocks.array() {
+            let css = (try? element.html()) ?? ""
+            if css.isEmpty { continue }
+            for raw in CSSImageURLExtractor.urlArgumentsFromBackgroundDeclarations(in: css) {
+                append(raw: raw, alt: nil)
             }
         }
 

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
@@ -57,4 +57,49 @@ final class StaticHTMLExtractorTests: XCTestCase {
         let picked = SrcSetParser.bestURL(from: srcset, baseURL: base)
         XCTAssertEqual(picked?.absoluteString, "https://example.com/b.png")
     }
+
+    func testInlineStyleBackgroundImageURL() throws {
+        let html = #"""
+        <div style="background-image: url('/root.png'), url(tile.png); color: red"></div>
+        """#
+        let page = URL(string: "https://example.com/dir/page")!
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: defaultConfig)
+        XCTAssertEqual(items.count, 2)
+        let urls = Set(items.map(\.sourceURL.absoluteString))
+        XCTAssertEqual(urls, ["https://example.com/root.png", "https://example.com/dir/tile.png"])
+        XCTAssertTrue(items.allSatisfy { $0.accessibilityLabel == nil })
+    }
+
+    func testStyleTagBackgroundDeclarations() throws {
+        let html = #"""
+        <style>
+          .hero { background-image: url("https://cdn.example.com/hero.webp"); }
+          .banner { background: no-repeat center url(/tile.png); }
+        </style>
+        """#
+        let page = URL(string: "https://example.com/")!
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: defaultConfig)
+        XCTAssertEqual(items.count, 2)
+        let urls = Set(items.map(\.sourceURL.absoluteString))
+        XCTAssertEqual(urls, [
+            "https://cdn.example.com/hero.webp",
+            "https://example.com/tile.png",
+        ])
+    }
+
+    func testDataAndFragmentURLsInCSSAreIgnored() throws {
+        let html = #"""
+        <div style="background-image: url(data:image/png;base64,AAAA), url(#sprite), url('https://example.com/ok.png')"></div>
+        """#
+        let page = URL(string: "https://example.com/")!
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: defaultConfig)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].sourceURL.absoluteString, "https://example.com/ok.png")
+    }
+
+    func testCSSURLExtractorUnit() {
+        let css = #"url( /a.png ), URL("https://x.test/b.png")"#
+        let args = CSSImageURLExtractor.urlArguments(from: css)
+        XCTAssertEqual(args, ["/a.png", "https://x.test/b.png"])
+    }
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use it when you want users to pull images from the web without leaving your app 
 
 - **Photos-like sheet** — Navigation stack with Cancel, Done (multi-select), and “Change URL” while browsing.
 - **URL entry first** — Text field with URL-friendly keyboard options where supported; loads the page on demand. Bare hosts (e.g. `example.com/path`) are **best-effort normalized** by prepending an allowed scheme (`https` preferred, then `http`, then other schemes in `allowedURLSchemes`). Users can still type an explicit `http://` URL when `http` is allowed.
-- **Static HTML extraction** — Collects `<img>`, `srcset`, `<picture>` sources, Open Graph, and Twitter card images; resolves relative URLs and deduplicates.
+- **Static HTML extraction** — Collects `<img>`, `srcset`, `<picture>` sources, Open Graph, Twitter card images, and **`url(...)` targets** from inline `style` attributes plus `<style>` blocks for `background-image` / `background` declarations; resolves relative URLs and deduplicates.
 - **WebView extraction mode** — Optional `WKWebView`-based discovery for JavaScript-rendered pages.
 - **Masonry layout** — Custom SwiftUI `Layout` with staggered columns (column count adapts by platform / size class).
 - **Configurable** — Selection limit, timeouts, size caps, allowed URL schemes, user agent, and extraction mode (extensible for future strategies).
@@ -128,6 +128,10 @@ UI strings and errors load from **`Localizable.strings`** under `Packages/WebIma
 
 1. **Fetch** — The active **`PageImageExtractor`** either downloads and parses raw HTML (**`.staticHTML`**, default, using [SwiftSoup](https://github.com/scinfu/SwiftSoup)) or loads the page in **`WKWebView`** (**`.webView`**) before collecting image candidates from the rendered DOM.
 2. **Discover** — Image candidates are parsed from the markup, normalized to absolute URLs, filtered by allowed schemes, and deduplicated.
+
+**Static HTML — what is included:** `<img>` / `srcset`, `<picture>` `<source>`, Open Graph and Twitter image meta tags, and CSS `url(...)` strings taken from (1) any inline `style` attribute and (2) `background-image` / `background` values inside `<style>` elements.
+
+**Static HTML — what is excluded (by design):** **`data:` URLs** (including `data:image/svg+xml`, …) are dropped so extraction stays bounded and avoids inlining huge payloads. **Same-document references** (`url(#id)`) are ignored because they do not name a network image. **Inline `<svg>` markup** is not traversed for nested raster `<image>` references in static mode (use **`.webView`** if you need the live DOM). External `.svg` files linked like any other `https` URL remain eligible when the scheme is allowed. Stylesheets loaded only via `<link rel="stylesheet">` are not fetched or parsed in static mode.
 3. **Present** — **`AsyncImage`** loads thumbnails in a **`MasonryLayout`**; the user selects one or more items (subject to the limit).
 4. **Deliver** — On Done (or single-tap when limit is 1), selected URLs are downloaded in bounded concurrency into **`WebImageSelection`** values.
 


### PR DESCRIPTION
## Summary
- Parse CSS `url(...)` from inline `style` attributes and from `background-image` / `background` values in `<style>` blocks in static HTML extraction.
- Ignore same-document `url(#...)` references; keep excluding `data:` URLs; document inline SVG / linked stylesheet limits in README.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- All 27 tests passed

Closes #12

Made with [Cursor](https://cursor.com)