### PR TITLE
Fix #13: Add GitHub issue/PR templates and label guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Report unexpected behavior or a regression
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please include enough detail for maintainers to reproduce or understand the failure.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong in one or two sentences?
+      placeholder: e.g. Picker shows no images for a specific URL after tapping Done.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Ordered steps, sample URL(s), and platform (iOS/macOS/etc.) if relevant.
+      placeholder: |
+        1. …
+        2. …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS version, Swift/Xcode if known, WebImagePicker version or commit, extraction mode (static vs WebView), etc.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Console output, screenshots, or minimal sample project (link or zip) if helpful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share the problem you are solving and how this change would help. Concrete examples make requests easier to evaluate.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What is hard, missing, or inconsistent today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: APIs, UX, or behavior you have in mind (optional if you only have the problem statement).
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Platforms, accessibility, performance, or compatibility notes.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+- What changed and why (short).
+
+## Test plan
+
+- [ ] `cd Packages/WebImagePicker && swift test` (or `swift test` from repo root)
+- [ ] Demo app / manual checks (if UI or platform-specific): …
+
+## Linked issues
+
+<!-- e.g. Closes #123 or Refs #456 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,21 @@ This project is under the [Mozilla Public License 2.0](LICENSE).
 - Keep changes **focused** on one concern when possible.
 - Run **`swift test`** (root or `Packages/WebImagePicker`) before opening a PR and note any platform-only checks you could not run.
 - Describe **what** changed and **why** in the PR body.
+- Use the PR template so reviewers get **summary**, **test plan**, and **linked issues**.
+
+## Labels (triage)
+
+Maintainers use labels to sort work. Typical meanings:
+
+| Label | When to use |
+| --- | --- |
+| `bug` | Incorrect behavior, regression, or spec violation |
+| `enhancement` | New capability, API, or meaningful improvement |
+| `documentation` | README, DocC, guides, or contributor-facing docs |
+| `good first issue` | Small, well-scoped task suitable for a first contribution |
+| `needs-repro` | Report is plausible but missing steps, environment, or a minimal repro |
+
+Issue templates apply **`bug`** and **`enhancement`** automatically when you pick those forms; other labels are added during triage.
 
 ## Release readiness (maintainers)
 


### PR DESCRIPTION
## Summary
- Added GitHub issue forms for bug reports and feature requests (with `bug` / `enhancement` labels).
- Added pull request template (summary, test plan, linked issues).
- Documented baseline label meanings in `CONTRIBUTING.md`.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- All 27 tests passed.

Closes #13

Made with [Cursor](https://cursor.com)