### PR TITLE
Fix #14: add release docs, changelog, and tag-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate SemVer tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if ! [[ "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release workflow: tag must be SemVer MAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH (got: $tag)"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Issue templates apply **`bug`** and **`enhancement`** automatically when you pic
 
 ## Release readiness (maintainers)
 
+For **versioning, changelog, tagging, and the automated GitHub Release workflow**, follow **[docs/RELEASE.md](docs/RELEASE.md)**.
+
 Before a release—especially one that introduces **binary** artifacts (XCFramework, etc.)—complete the privacy and manifest checklist in **[docs/PRIVACY_MANIFEST.md](docs/PRIVACY_MANIFEST.md)** so `PrivacyInfo.xcprivacy` and distribution expectations stay accurate.
 
 ## Questions

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,41 @@
+# Releasing WebImagePicker
+
+This document is for **maintainers** cutting versioned releases consumers can pin in SwiftPM.
+
+## Versioning
+
+- Use **Semantic Versioning** (`MAJOR.MINOR.PATCH`). Tags are the source of truth SwiftPM resolves against the repository URL.
+- **Recommended tag form:** plain `MAJOR.MINOR.PATCH` (for example `1.2.0`), matching the examples in [README.md](../README.md). You may alternatively use a `v` prefix (`v1.2.0`) if you prefer; the release workflow accepts either form.
+- **MAJOR** — incompatible API or behavior changes for consumers.
+- **MINOR** — backward-compatible additions.
+- **PATCH** — backward-compatible fixes.
+
+Pre-release identifiers (for example `1.0.0-beta.1`) are not created automatically by the tag-based workflow; if you need them, add a workflow or manual release step later.
+
+## Changelog
+
+1. Under **`## [Unreleased]`** in [CHANGELOG.md](../CHANGELOG.md), add concise bullets under the right subsection (`Added`, `Changed`, `Fixed`, `Removed`).
+2. When you tag a release, add a new section **`## [X.Y.Z] — YYYY-MM-DD`** above `[Unreleased]` and move the relevant bullets out of `[Unreleased]` into that section (leave empty subsections out or delete them).
+3. Commit the changelog update on **`main`** (or merge a PR) **before** creating the tag so the tagged revision includes accurate notes.
+
+## Release checklist
+
+1. **`main` is green** — CI passes on the commit you intend to release.
+2. **Changelog** — `[Unreleased]` updated; new `## [X.Y.Z]` section prepared as above.
+3. **Privacy / distribution** — If the release introduces or changes binary artifacts or collection behavior, complete [PRIVACY_MANIFEST.md](PRIVACY_MANIFEST.md).
+4. **Tag from the release commit:**
+
+   ```bash
+   git checkout main
+   git pull --ff-only origin main
+   git tag -a 1.2.0 -m "Release 1.2.0"
+   git push origin 1.2.0
+   ```
+
+   Use an annotated tag (`-a`) so the tag message records the release intent.
+
+5. **GitHub Release** — Pushing a valid SemVer tag triggers [.github/workflows/release.yml](../.github/workflows/release.yml), which creates a GitHub Release with generated notes. Edit the release on GitHub if you want a richer summary or links.
+
+## Consumer integration
+
+Apps should depend on the **repository root** URL with `from: "X.Y.Z"` (or an exact `exactVersion` / revision) as documented in the README. After pushing the tag, SwiftPM can resolve the new version once caches refresh.


### PR DESCRIPTION
## Summary
- Add maintainer-facing `docs/RELEASE.md` with SemVer tagging steps, changelog discipline, and release checklist (including privacy manifest link).
- Add Keep a Changelog–style `CHANGELOG.md` with an `[Unreleased]` section.
- Add `.github/workflows/release.yml` to create a GitHub Release with generated notes when a SemVer tag (`X.Y.Z` or `vX.Y.Z`) is pushed; validates tag format before publishing.
- Link the release guide from `CONTRIBUTING.md`.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- All 27 tests passed.

Closes #14

Made with [Cursor](https://cursor.com)