### PR TITLE
Fix #15: Add DocC catalog and public API documentation

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/GettingStarted.md
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/GettingStarted.md
@@ -1,0 +1,34 @@
+# Getting started with WebImagePicker
+
+Present the picker from SwiftUI and handle downloaded selections.
+
+## Overview
+
+Use ``View/webImagePicker(isPresented:configuration:onPick:)`` for a sheet that dismisses after a successful pick, or embed ``WebImagePicker`` directly when you need custom dismissal with `onCancel` / `onPick`.
+
+## Present with the view modifier
+
+```swift
+import SwiftUI
+import WebImagePicker
+
+struct ContentView: View {
+    @State private var showPicker = false
+    @State private var selections: [WebImageSelection] = []
+
+    var body: some View {
+        Button("Pick from web") { showPicker = true }
+            .webImagePicker(isPresented: $showPicker) { newSelections in
+                selections = newSelections
+            }
+    }
+}
+```
+
+## Configure limits and extraction
+
+Build a ``WebImagePickerConfiguration`` to cap selection count, tune network limits, restrict URL schemes, and choose ``WebImageExtractionMode`` (static HTML vs. WebView). Pass it into ``View/webImagePicker(isPresented:configuration:onPick:)`` or ``WebImagePicker/init(configuration:onCancel:onPick:)``.
+
+## Use the selection
+
+Each ``WebImageSelection`` exposes `data`, `contentType`, and `sourceURL`. On iOS, tvOS, or visionOS, call ``WebImageSelection/makeUIImage()``; on macOS, ``WebImageSelection/makeNSImage()``.

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/WebImagePicker.md
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/WebImagePicker.md
@@ -1,0 +1,33 @@
+# ``WebImagePicker``
+
+Browse and pick images discovered on a web page, with a Photos-style sheet, configurable extraction, and typed results.
+
+@Metadata {
+    @TechnologyRoot()
+}
+
+## Overview
+
+Add the library to your app target, then present ``WebImagePicker`` or use the ``View/webImagePicker(isPresented:configuration:onPick:)`` modifier. Configure behavior with ``WebImagePickerConfiguration`` (including ``WebImageExtractionMode``). User choices are delivered as ``WebImageSelection`` values containing raw bytes, optional MIME type, and source URL.
+
+On Apple platforms, use ``WebImageSelection/makeUIImage()`` or ``WebImageSelection/makeNSImage()`` to decode platform images when available.
+
+## Topics
+
+### Essentials
+
+- ``WebImagePicker``
+- ``View/webImagePicker(isPresented:configuration:onPick:)``
+
+### Configuration
+
+- ``WebImagePickerConfiguration``
+- ``WebImageExtractionMode``
+
+### Selection
+
+- ``WebImageSelection``
+
+### Articles
+
+- <doc:GettingStarted>

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.swift
@@ -2,6 +2,10 @@ import Foundation
 import SwiftUI
 
 /// A Photos-style flow for picking images discovered on a web page.
+///
+/// The picker loads a URL you provide, discovers image candidates (see ``WebImagePickerConfiguration/extractionMode``),
+/// and presents them in a masonry grid. Use ``init(configuration:onCancel:onPick:)`` for full control over dismissal,
+/// or ``View/webImagePicker(isPresented:configuration:onPick:)`` to present in a sheet that dismisses after a successful pick.
 public struct WebImagePicker: View {
     private let configuration: WebImagePickerConfiguration
     private let onCancel: () -> Void
@@ -13,6 +17,11 @@ public struct WebImagePicker: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 #endif
 
+    /// Creates a picker with configuration and completion handlers.
+    /// - Parameters:
+    ///   - configuration: Limits, timeouts, allowed schemes, and HTML vs. WebView extraction. Default is ``WebImagePickerConfiguration/default``.
+    ///   - onCancel: Called when the user cancels (toolbar).
+    ///   - onPick: Called with one or more ``WebImageSelection`` values after a successful pick.
     public init(
         configuration: WebImagePickerConfiguration = .default,
         onCancel: @escaping () -> Void,
@@ -273,6 +282,12 @@ private struct DiscoveredImageTile: View {
 
 public extension View {
     /// Presents ``WebImagePicker`` in a sheet and dismisses it after a successful pick.
+    ///
+    /// Cancel dismisses the sheet without calling `onPick`. On success, `onPick` receives the selections and the sheet is dismissed.
+    /// - Parameters:
+    ///   - isPresented: Controls sheet visibility.
+    ///   - configuration: Behavior and network limits; defaults to ``WebImagePickerConfiguration/default``.
+    ///   - onPick: Invoked with downloaded ``WebImageSelection`` values when the user confirms (or single-taps when the limit is 1).
     func webImagePicker(
         isPresented: Binding<Bool>,
         configuration: WebImagePickerConfiguration = .default,

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -12,6 +12,9 @@ public enum WebImageExtractionMode: Sendable, Hashable {
     case webView
 }
 
+/// Tunable behavior for ``WebImagePicker`` and ``View/webImagePicker(isPresented:configuration:onPick:)``.
+///
+/// Use ``default`` for HTTPS-only pages, multi-select up to 10, static HTML extraction, and shared `URLSession`.
 public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// Maximum number of images the user may select. Use `1` for single selection.
     public var selectionLimit: Int
@@ -39,6 +42,17 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
+    /// Creates a configuration with explicit limits and networking options.
+    /// - Parameters:
+    ///   - selectionLimit: Maximum selections; clamped to at least `1`.
+    ///   - maximumConcurrentImageLoads: Parallel downloads when confirming a multi-select.
+    ///   - requestTimeout: Per-request timeout for HTML and image fetches.
+    ///   - allowedURLSchemes: Schemes allowed for page and image URLs (e.g. `https` only by default).
+    ///   - userAgent: Optional HTTP `User-Agent` header.
+    ///   - maximumHTMLDownloadBytes: Upper bound on HTML response size.
+    ///   - maximumImageDownloadBytes: Upper bound on each image response.
+    ///   - extractionMode: ``WebImageExtractionMode/staticHTML`` or ``WebImageExtractionMode/webView``.
+    ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 10,
         maximumConcurrentImageLoads: Int = 4,

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelection.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelection.swift
@@ -1,11 +1,17 @@
 import Foundation
 
 /// A downloaded image chosen by the user, including raw bytes and metadata.
+///
+/// Decode with ``makeUIImage()`` on iOS, tvOS, or visionOS, or ``makeNSImage()`` on macOS when those APIs are available.
 public struct WebImageSelection: Sendable, Hashable {
+    /// Raw image bytes returned by the network response.
     public let data: Data
+    /// MIME type from the response, when provided (e.g. `image/jpeg`).
     public let contentType: String?
+    /// Absolute URL of the downloaded image.
     public let sourceURL: URL
 
+    /// Creates a selection value (primarily for tests and advanced integration).
     public init(data: Data, contentType: String?, sourceURL: URL) {
         self.data = data
         self.contentType = contentType

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Use **`.staticHTML`** for fastest extraction on server-rendered pages. Use **`.w
 
 This repository includes a small **SwiftUI** demo target (**SwiftUI Web Image Picker**) that links the local package and shows selected images. Open **`SwiftUI Web Image Picker.xcodeproj`** in Xcode and run the scheme on your chosen destination.
 
+## API reference (DocC)
+
+The Swift package ships a **DocC** catalog for the public API:
+
+- **Location:** [`Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/`](Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/)
+
+**Browse in Xcode:** open `SwiftUI Web Image Picker.xcodeproj` or add the package, then choose **Product → Build Documentation** and open the **WebImagePicker** documentation in the Documentation navigator. Entry points include `WebImagePicker`, the `webImagePicker` view modifier, `WebImagePickerConfiguration`, and `WebImageSelection`.
+
 ## Development
 
 From the **repository root** (canonical for CI and URL-based SPM):


### PR DESCRIPTION
## Summary
- Add DocC technology root (`WebImagePicker.docc`) with topic groups and a Getting Started article.
- Expand documentation comments on `WebImagePicker`, `webImagePicker`, `WebImagePickerConfiguration`, and `WebImageSelection`.
- Link README to the DocC catalog location and Xcode **Build Documentation** workflow.

## Test plan
- `cd Packages/WebImagePicker && swift test` — all 27 tests passed.
- `swift build` from repo root — succeeded.
- `swift package dump-symbol-graph` (nested package) — symbol graphs emitted for `WebImagePicker`.

Closes #15

Made with [Cursor](https://cursor.com)