### PR TITLE
Fix #26: PR workflow for snapshot screenshots and docs

### DIFF
--- a/.github/workflows/pr-visual-changelog.yml
+++ b/.github/workflows/pr-visual-changelog.yml
@@ -1,0 +1,55 @@
+# Publishes macOS SwiftPM snapshot PNGs for each PR (artifacts + sticky comment).
+# Not a merge gate — required checks stay on CI (swift-package). See docs/pr-visual-changelog.md.
+name: PR visual changelog
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  publish-snapshots:
+    name: Snapshot PNGs (macOS SwiftPM)
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: Packages/WebImagePicker
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Test package (includes macOS snapshot tests)
+        run: swift test
+
+      - name: Bundle PNGs for artifact
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p visual-changelog
+          find Packages/WebImagePicker/Tests/WebImagePickerTests/__Snapshots__ -name '*.png' -print -exec cp {} visual-changelog/ \;
+
+      - name: Upload screenshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-screenshots
+          path: visual-changelog/*.png
+          if-no-files-found: warn
+
+      - name: Post sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        continue-on-error: true
+        with:
+          header: pr-visual-changelog
+          recreate: true
+          message: |
+            ## Visual changelog (automated)
+
+            **macOS** SwiftPM snapshot PNGs from `WebImagePickerSnapshotTests` for commit `${{ github.event.pull_request.head.sha }}` are in workflow artifacts (same images CI uses for layout regression).
+
+            **Download:** [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) → **Artifacts** → `pr-screenshots`.
+
+            The full **SwiftUI Web Image Picker** demo app is Xcode-only (signing); see [docs/pr-visual-changelog.md](https://github.com/${{ github.repository }}/blob/main/docs/pr-visual-changelog.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ This project is under the [Mozilla Public License 2.0](LICENSE).
 
 ## Pull requests
 
+- **Visual changelog** — opening a PR against `main` runs [PR visual changelog](.github/workflows/pr-visual-changelog.yml), which uploads macOS snapshot PNGs and links them in a sticky comment. See **[docs/pr-visual-changelog.md](docs/pr-visual-changelog.md)** for scope (SwiftPM vs. Xcode demo) and how this differs from required CI checks.
 - Keep changes **focused** on one concern when possible.
 - Run **`swift test`** (root or `Packages/WebImagePicker`) before opening a PR and note any platform-only checks you could not run.
 - Describe **what** changed and **why** in the PR body.

--- a/docs/pr-visual-changelog.md
+++ b/docs/pr-visual-changelog.md
@@ -1,0 +1,29 @@
+# PR visual changelog (automation)
+
+## What runs
+
+The workflow [`.github/workflows/pr-visual-changelog.yml`](../.github/workflows/pr-visual-changelog.yml) runs on **pull requests** targeting `main`.
+
+1. **Checkout** and run **`swift test`** under `Packages/WebImagePicker` on **`macos-latest`** (same stack as the main CI SwiftPM job).
+2. **Copy** every `*.png` under `Tests/WebImagePickerTests/__Snapshots__/` into a bundle.
+3. **Upload** that bundle as the **`pr-screenshots`** workflow artifact.
+4. **Post or update** a **sticky bot comment** on the PR with a link to the workflow run so reviewers can download the PNGs.
+
+This gives reviewers **automatic visual evidence** of the URL-entry (and any future) snapshot screens **without building locally**.
+
+## Required checks vs. this workflow
+
+- **Required:** [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) — `swift build` + `swift test` (including macOS snapshots).
+- **Informational:** **PR visual changelog** — must not block merges if it is flaky or if commenting is unavailable (e.g. some fork PR token limits). The sticky comment step uses `continue-on-error: true` so those cases do not fail the job.
+
+## macOS vs. iOS / demo app
+
+| Surface | In this workflow |
+|--------|-------------------|
+| **macOS** | SwiftPM tests render `WebImagePicker` in an `NSHostingView` and assert against PNG baselines in `__Snapshots__/`. Those PNGs are what we attach as artifacts. |
+| **iOS / tvOS / visionOS** | Snapshot tests **skip** on non-macOS destinations (see `WebImagePickerSnapshotTests`); CI does not produce simulator PNGs here. |
+| **Xcode demo** (`SwiftUI Web Image Picker.xcodeproj`) | **Not** built in GitHub Actions (signing / team setup). Run the demo locally per [CONTRIBUTING.md](../CONTRIBUTING.md) for full-app previews. |
+
+## Fork pull requests
+
+Artifact upload uses the default `contents: read` workflow token. Posting a sticky comment needs `pull-requests: write`, which is **not** granted to workflows from forked repos in the same way. The comment step may no-op or warn; snapshots may still appear under **Actions** artifacts for that run when uploads succeed.


### PR DESCRIPTION
## Summary
- Add `pr-visual-changelog.yml` workflow on `pull_request` to `main`: run `swift test` on macOS, upload `__Snapshots__` PNGs as `pr-screenshots` artifact, post/update sticky PR comment with workflow run link.
- Document macOS SwiftPM vs Xcode demo / fork behavior in `docs/pr-visual-changelog.md` and link from `CONTRIBUTING.md`.
- Sticky comment step uses `continue-on-error: true` so token limits on fork PRs do not fail the job; merge gate remains `ci.yml`.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: all 37 tests passed (including `WebImagePickerSnapshotTests` on macOS).

Closes #26

Made with [Cursor](https://cursor.com)