### PR TITLE
Fix #35: first-class demo onboarding and sample URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Thanks for helping improve **SwiftUI Web Image Picker**.
 
    On iOS, tvOS, or visionOS destinations, snapshot tests are skipped (`XCTSkip`) because baselines are macOS PNGs.
 
-4. **Demo app** — open **`SwiftUI Web Image Picker.xcodeproj`** in Xcode, choose the **SwiftUI Web Image Picker** scheme, and run on your Mac or a simulator.
+4. **Demo app** — open **`SwiftUI Web Image Picker.xcodeproj`** in Xcode, choose the **SwiftUI Web Image Picker** scheme, and run on your Mac, a simulator, or visionOS. Use **Try a sample page** in the demo for pre-filled URLs, or type your own. The root README **Quick try** section is the onboarding path for new contributors.
 
 ### Code signing (demo target)
 

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/GettingStarted.md
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/GettingStarted.md
@@ -32,3 +32,7 @@ Build a ``WebImagePickerConfiguration`` to cap selection count, tune network lim
 ## Use the selection
 
 Each ``WebImageSelection`` exposes `data`, `contentType`, and `sourceURL`. On iOS, tvOS, or visionOS, call ``WebImageSelection/makeUIImage()``; on macOS, ``WebImageSelection/makeNSImage()``.
+
+## Runnable demo in this repository
+
+The **SwiftUI Web Image Picker** app at the root of [the package repository](https://github.com/fennelouski/SwiftUI-Web-Image-Picker) is the recommended place to experiment. Open `SwiftUI Web Image Picker.xcodeproj`, run the **SwiftUI Web Image Picker** scheme, and use **Pick from web** or the sample-page menu. The README **Quick try** section has step-by-step setup (including signing).

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -39,6 +39,9 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
 
     public var extractionMode: WebImageExtractionMode
 
+    /// Optional text pre-filled in the URL field when the picker appears (whitespace trimmed). Empty or `nil` means a blank field.
+    public var initialURLString: String?
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -52,6 +55,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - maximumHTMLDownloadBytes: Upper bound on HTML response size.
     ///   - maximumImageDownloadBytes: Upper bound on each image response.
     ///   - extractionMode: ``WebImageExtractionMode/staticHTML`` or ``WebImageExtractionMode/webView``.
+    ///   - initialURLString: Optional URL string shown in the entry field when the picker first appears.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 10,
@@ -62,6 +66,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         maximumHTMLDownloadBytes: Int = 2_000_000,
         maximumImageDownloadBytes: Int = 25_000_000,
         extractionMode: WebImageExtractionMode = .staticHTML,
+        initialURLString: String? = nil,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -72,6 +77,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.maximumHTMLDownloadBytes = maximumHTMLDownloadBytes
         self.maximumImageDownloadBytes = maximumImageDownloadBytes
         self.extractionMode = extractionMode
+        self.initialURLString = initialURLString
         self.urlSession = urlSession
     }
 
@@ -86,6 +92,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.maximumHTMLDownloadBytes == rhs.maximumHTMLDownloadBytes
             && lhs.maximumImageDownloadBytes == rhs.maximumImageDownloadBytes
             && lhs.extractionMode == rhs.extractionMode
+            && lhs.initialURLString == rhs.initialURLString
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -97,5 +104,6 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(maximumHTMLDownloadBytes)
         hasher.combine(maximumImageDownloadBytes)
         hasher.combine(extractionMode)
+        hasher.combine(initialURLString)
     }
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
@@ -23,6 +23,9 @@ final class WebImagePickerViewModel {
     init(configuration: WebImagePickerConfiguration) {
         self.configuration = configuration
         extractor = configuration.extractionMode.makeExtractor()
+        if let raw = configuration.initialURLString?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
+            urlString = raw
+        }
     }
 
     func loadPage() async {

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -55,4 +55,14 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         let b = WebImagePickerConfiguration(urlSession: custom)
         XCTAssertEqual(a, b)
     }
+
+    func testInitialURLStringAffectsEquality() {
+        let a = WebImagePickerConfiguration(initialURLString: "https://a.example")
+        let b = WebImagePickerConfiguration(initialURLString: "https://b.example")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testDefaultInitialURLStringIsNil() {
+        XCTAssertNil(WebImagePickerConfiguration.default.initialURLString)
+    }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerViewModelInitialURLTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerViewModelInitialURLTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import WebImagePicker
+
+@MainActor
+final class WebImagePickerViewModelInitialURLTests: XCTestCase {
+    func testInitialURLStringPreFillsField() {
+        let config = WebImagePickerConfiguration(initialURLString: "  https://example.com/path  ")
+        let model = WebImagePickerViewModel(configuration: config)
+        XCTAssertEqual(model.urlString, "https://example.com/path")
+    }
+
+    func testNilInitialURLStringLeavesFieldEmpty() {
+        let model = WebImagePickerViewModel(configuration: .default)
+        XCTAssertTrue(model.urlString.isEmpty)
+    }
+
+    func testWhitespaceOnlyInitialURLStringLeavesFieldEmpty() {
+        let config = WebImagePickerConfiguration(initialURLString: "   \n")
+        let model = WebImagePickerViewModel(configuration: config)
+        XCTAssertTrue(model.urlString.isEmpty)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A Swift Package that brings **web pages into an image-picking flow** similar to 
 
 Use it when you want users to pull images from the web without leaving your app or juggling Safari and the clipboard.
 
+## Quick try (~5 minutes)
+
+**Start here:** the repo ships a small SwiftUI app that links **WebImagePicker** locally so you can learn the flow without wiring SPM into your own project first.
+
+1. **Clone** — `git clone https://github.com/fennelouski/SwiftUI-Web-Image-Picker.git` and `cd` into the folder.
+2. **Open** — **`SwiftUI Web Image Picker.xcodeproj`** in Xcode.
+3. **Scheme** — choose **SwiftUI Web Image Picker** in the scheme picker next to Run/Stop.
+4. **Destination** — an **iOS Simulator**, **My Mac**, or a **visionOS** simulator (the demo is multiplatform).
+5. **Signing** — if Xcode complains, select the app target → **Signing & Capabilities** → enable **Automatically manage signing** and pick a **Team** (Personal Team is fine for local runs). See **[CONTRIBUTING.md](CONTRIBUTING.md#code-signing-demo-target)**—do not commit team IDs.
+6. **Run** — **Product → Run** (⌘R). Tap **Pick from web** and type a URL, or open **Try a sample page** for a pre-filled HTTPS URL, then **Load page**, select thumbnails, and **Done**.
+
+When you are ready to integrate, follow **[Installation](#installation)** and **[Quick start](#quick-start)** below.
+
 ## Features
 
 - **Photos-like sheet** — Navigation stack with Cancel, Done (multi-select), and “Change URL” while browsing.
@@ -141,10 +154,6 @@ Use **`.staticHTML`** for fastest extraction on server-rendered pages. Use **`.w
 - Runs WebKit work on the main actor and can use more memory/CPU than static parsing.
 - Subject to platform sandbox/network policy (for example, App Sandbox outgoing network permission on macOS).
 - Embedded/isolated content (cross-origin iframes, blocked resources, CSP constraints) may still limit what becomes discoverable.
-
-## Demo app
-
-This repository includes a small **SwiftUI** demo target (**SwiftUI Web Image Picker**) that links the local package and shows selected images. Open **`SwiftUI Web Image Picker.xcodeproj`** in Xcode and run the scheme on your chosen destination.
 
 ## API reference (DocC)
 

--- a/SwiftUI Web Image Picker/ContentView.swift
+++ b/SwiftUI Web Image Picker/ContentView.swift
@@ -2,7 +2,9 @@
 //  ContentView.swift
 //  SwiftUI Web Image Picker
 //
-//  Created by Nathan Fennel on 5/1/26.
+//  Demo integration: present `WebImagePicker` with `.webImagePicker(isPresented:configuration:onPick:)`.
+//  Each presentation uses a fresh `WebImagePickerConfiguration` so `initialURLString` can pre-fill
+//  the URL field when launching from a sample page.
 //
 
 import SwiftUI
@@ -11,14 +13,38 @@ import WebImagePicker
 struct ContentView: View {
     @State private var showPicker = false
     @State private var selections: [WebImageSelection] = []
+    @State private var pickerConfiguration = WebImagePickerConfiguration(selectionLimit: 5)
+
+    /// Static HTML–heavy pages that work well with default `.staticHTML` extraction.
+    private enum SamplePage: String, CaseIterable {
+        case wikipediaCat = "https://en.wikipedia.org/wiki/Cat"
+        case apple = "https://www.apple.com/"
+        case mozilla = "https://www.mozilla.org/"
+
+        var menuTitle: String {
+            switch self {
+            case .wikipediaCat: "Wikipedia — Cat"
+            case .apple: "Apple.com"
+            case .mozilla: "Mozilla.org"
+            }
+        }
+    }
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
                 Button("Pick from web") {
-                    showPicker = true
+                    presentPicker(initialURL: nil)
                 }
                 .buttonStyle(.borderedProminent)
+
+                Menu("Try a sample page") {
+                    ForEach(SamplePage.allCases, id: \.self) { page in
+                        Button(page.menuTitle) {
+                            presentPicker(initialURL: page.rawValue)
+                        }
+                    }
+                }
 
                 if selections.isEmpty {
                     Text("No images selected yet.")
@@ -40,9 +66,17 @@ struct ContentView: View {
             .padding()
             .navigationTitle("Web Image Picker")
         }
-        .webImagePicker(isPresented: $showPicker, configuration: .init(selectionLimit: 5)) { newSelections in
+        .webImagePicker(isPresented: $showPicker, configuration: pickerConfiguration) { newSelections in
             selections = newSelections
         }
+    }
+
+    private func presentPicker(initialURL: String?) {
+        pickerConfiguration = WebImagePickerConfiguration(
+            selectionLimit: 5,
+            initialURLString: initialURL
+        )
+        showPicker = true
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Add a README **Quick try (~5 minutes)** section: clone, open `SwiftUI Web Image Picker.xcodeproj`, scheme, signing link, run, and what to tap (including **Try a sample page**).
- Demo app: **Try a sample page** menu with HTTPS pages that work well with static HTML extraction; each opens the picker with a pre-filled URL.
- New `WebImagePickerConfiguration.initialURLString` seeds the URL field; `WebImagePickerViewModel` applies it on init.
- DocC **GettingStarted** and **CONTRIBUTING** point to the demo as the primary learning path for newcomers.
- Unit tests for initial URL behavior and configuration equality.

## Test plan
- `cd Packages/WebImagePicker && swift test` — all 42 tests passed
- `swift test` from repo root — all 42 tests passed

Closes #35

Made with [Cursor](https://cursor.com)