### PR TITLE
Fix #37: Cap discovered images per page

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
@@ -20,7 +20,10 @@ enum AggregatedPageImageDiscovery {
 
         for pageURL in pageURLs {
             do {
-                let items = try await extractor.discoverImages(from: pageURL, configuration: configuration)
+                var items = try await extractor.discoverImages(from: pageURL, configuration: configuration)
+                if let cap = configuration.maximumDiscoveredImagesPerPage {
+                    items = Array(items.prefix(cap))
+                }
                 for item in items {
                     let key = item.sourceURL.absoluteString
                     guard !seenImageKeys.contains(key) else { continue }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -47,6 +47,11 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// Host apps can pre-seed several pages; invalid schemes are skipped. Discovery runs sequentially to keep ordering predictable.
     public var additionalPageURLs: [URL]
 
+    /// Upper bound on how many images to keep from each page after discovery, before they are merged into the grid.
+    ///
+    /// When `nil` (the default), no truncation is applied. When set to a positive value, only the first N candidates from that page are kept, in the order produced by the active ``PageImageExtractor`` (see package documentation for static HTML ordering). The cap applies **per page**: in multi-URL mode, each loaded page contributes at most N images (after per-page deduplication).
+    public var maximumDiscoveredImagesPerPage: Int?
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -62,6 +67,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - extractionMode: ``WebImageExtractionMode/staticHTML`` or ``WebImageExtractionMode/webView``.
     ///   - initialURLString: Optional URL string shown in the entry field when the picker first appears.
     ///   - additionalPageURLs: Ordered extra pages to aggregate with the primary URL and any user-added URLs.
+    ///   - maximumDiscoveredImagesPerPage: Optional maximum images retained per page after discovery; `nil` means unlimited.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 10,
@@ -74,6 +80,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         extractionMode: WebImageExtractionMode = .staticHTML,
         initialURLString: String? = nil,
         additionalPageURLs: [URL] = [],
+        maximumDiscoveredImagesPerPage: Int? = nil,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -86,6 +93,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.extractionMode = extractionMode
         self.initialURLString = initialURLString
         self.additionalPageURLs = additionalPageURLs
+        self.maximumDiscoveredImagesPerPage = maximumDiscoveredImagesPerPage.flatMap { $0 > 0 ? $0 : nil }
         self.urlSession = urlSession
     }
 
@@ -100,8 +108,9 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.maximumHTMLDownloadBytes == rhs.maximumHTMLDownloadBytes
             && lhs.maximumImageDownloadBytes == rhs.maximumImageDownloadBytes
             && lhs.extractionMode == rhs.extractionMode
-            && lhs.initialURLString == rhs.initialURLString
+            &&         lhs.initialURLString == rhs.initialURLString
             && lhs.additionalPageURLs == rhs.additionalPageURLs
+            && lhs.maximumDiscoveredImagesPerPage == rhs.maximumDiscoveredImagesPerPage
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -115,5 +124,6 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(extractionMode)
         hasher.combine(initialURLString)
         hasher.combine(additionalPageURLs)
+        hasher.combine(maximumDiscoveredImagesPerPage)
     }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
@@ -83,4 +83,58 @@ final class AggregatedPageImageDiscoveryTests: XCTestCase {
         XCTAssertEqual(Set(merge.failedPageURLs), Set([u1, u2]))
         XCTAssertTrue(merge.images.isEmpty)
     }
+
+    func testPerPageCapKeepsFirstImagesInDiscoveryOrder() async throws {
+        let page = URL(string: "https://one.example/")!
+        let u1 = URL(string: "https://cdn.example/1.png")!
+        let u2 = URL(string: "https://cdn.example/2.png")!
+        let u3 = URL(string: "https://cdn.example/3.png")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            page: .success([
+                DiscoveredImage(sourceURL: u1, accessibilityLabel: "a"),
+                DiscoveredImage(sourceURL: u2, accessibilityLabel: "b"),
+                DiscoveredImage(sourceURL: u3, accessibilityLabel: "c"),
+            ]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.maximumDiscoveredImagesPerPage = 2
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [page],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertTrue(merge.failedPageURLs.isEmpty)
+        XCTAssertEqual(merge.images.map(\.sourceURL), [u1, u2])
+        XCTAssertEqual(merge.images.map(\.accessibilityLabel), ["a", "b"])
+    }
+
+    func testPerPageCapAppliesIndependentlyForEachPage() async throws {
+        let a = URL(string: "https://a.example/")!
+        let b = URL(string: "https://b.example/")!
+        let imgsA = (1 ... 4).map { URL(string: "https://cdn.example/a\($0).png")! }
+        let imgsB = (1 ... 3).map { URL(string: "https://cdn.example/b\($0).png")! }
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            a: .success(imgsA.map { DiscoveredImage(sourceURL: $0, accessibilityLabel: nil) }),
+            b: .success(imgsB.map { DiscoveredImage(sourceURL: $0, accessibilityLabel: nil) }),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.maximumDiscoveredImagesPerPage = 2
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [a, b],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertEqual(
+            merge.images.map(\.sourceURL),
+            [imgsA[0], imgsA[1], imgsB[0], imgsB[1]]
+        )
+    }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
@@ -33,6 +33,22 @@ final class StaticHTMLExtractorTests: XCTestCase {
         XCTAssertEqual(items.count, 1)
     }
 
+    /// Document order for static extraction: `<img>` elements (DOM order) before Open Graph / Twitter meta images.
+    func testImgElementsPrecedeOgImageInDiscoveryOrder() throws {
+        let html = #"""
+        <html><body>
+        <img src="https://example.com/first.png" alt="">
+        <meta property="og:image" content="https://example.com/og.png">
+        </body></html>
+        """#
+        let page = URL(string: "https://example.com/")!
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: defaultConfig)
+        XCTAssertEqual(items.map(\.sourceURL.absoluteString), [
+            "https://example.com/first.png",
+            "https://example.com/og.png",
+        ])
+    }
+
     func testFiltersByAllowedScheme() throws {
         let html = #"<img src="ftp://bad.example/a.png">"#
         let page = URL(string: "https://example.com/")!

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -70,6 +70,21 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         XCTAssertTrue(WebImagePickerConfiguration.default.additionalPageURLs.isEmpty)
     }
 
+    func testDefaultMaximumDiscoveredImagesPerPageIsNil() {
+        XCTAssertNil(WebImagePickerConfiguration.default.maximumDiscoveredImagesPerPage)
+    }
+
+    func testMaximumDiscoveredImagesPerPageNonPositiveBecomesNil() {
+        XCTAssertNil(WebImagePickerConfiguration(maximumDiscoveredImagesPerPage: 0).maximumDiscoveredImagesPerPage)
+        XCTAssertNil(WebImagePickerConfiguration(maximumDiscoveredImagesPerPage: -1).maximumDiscoveredImagesPerPage)
+    }
+
+    func testMaximumDiscoveredImagesPerPageAffectsEquality() {
+        let capped = WebImagePickerConfiguration(maximumDiscoveredImagesPerPage: 5)
+        let uncapped = WebImagePickerConfiguration(maximumDiscoveredImagesPerPage: nil)
+        XCTAssertNotEqual(capped, uncapped)
+    }
+
     func testAdditionalPageURLsAffectsEquality() throws {
         let u = try XCTUnwrap(URL(string: "https://a.example/"))
         let withExtra = WebImagePickerConfiguration(additionalPageURLs: [u])

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ var config = WebImagePickerConfiguration(
 
 With **`selectionLimit == 1`**, tapping an image downloads it immediately and completes the pick (no separate Done step).
 
+**`maximumDiscoveredImagesPerPage`** — Optional cap on how many image candidates are kept from **each** loaded page after discovery (default `nil` = unlimited). Truncation keeps the first N URLs in extractor order. For **`.staticHTML`**, that order is: `<img>` / `srcset` and `<picture>` sources in DOM order, then Open Graph and Twitter image tags, then `url(...)` values from inline `style` attributes and `<style>` blocks. In **multi-URL** mode (primary field + `additionalPageURLs` + extra rows), the limit applies **per page** before results are merged and de-duplicated across pages.
+
 ### Localization
 
 UI strings and errors load from **`Localizable.strings`** under `Packages/WebImagePicker/Sources/WebImagePicker/Resources/` (e.g. `en.lproj`, `es.lproj`). The picker follows the user’s preferred language when a matching localization exists. To add or adjust translations, edit those files in the package and ship an updated dependency revision.
@@ -140,7 +142,7 @@ UI strings and errors load from **`Localizable.strings`** under `Packages/WebIma
 ## How it works
 
 1. **Fetch** — The active **`PageImageExtractor`** either downloads and parses raw HTML (**`.staticHTML`**, default, using [SwiftSoup](https://github.com/scinfu/SwiftSoup)) or loads the page in **`WKWebView`** (**`.webView`**) before collecting image candidates from the rendered DOM.
-2. **Discover** — Image candidates are parsed from the markup, normalized to absolute URLs, filtered by allowed schemes, and deduplicated.
+2. **Discover** — Image candidates are parsed from the markup, normalized to absolute URLs, filtered by allowed schemes, and deduplicated. If **`maximumDiscoveredImagesPerPage`** is set, each page’s list is truncated to that many candidates (in discovery order) before the grid is shown.
 
 **Static HTML — what is included:** `<img>` / `srcset`, `<picture>` `<source>`, Open Graph and Twitter image meta tags, and CSS `url(...)` strings taken from (1) any inline `style` attribute and (2) `background-image` / `background` values inside `<style>` elements.
 


### PR DESCRIPTION
## Summary
- Add optional `maximumDiscoveredImagesPerPage` to `WebImagePickerConfiguration` (default `nil` = unlimited; non-positive values treated as no cap).
- Apply truncation in `AggregatedPageImageDiscovery` after each page’s extraction, preserving extractor discovery order before cross-page merge.
- Document behavior and static-HTML ordering in README.
- Unit tests for per-page caps, multi-URL independence, configuration defaults/equality, and static HTML img-before-og ordering.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: all 55 tests passed

Closes #37

Made with [Cursor](https://cursor.com)