### PR TITLE
Fix #38: configurable URL normalization for similar image deduplication

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Loads image candidates from several page URLs, merges them in page order, and deduplicates by image URL.
+/// Loads image candidates from several page URLs, merges them in page order, and deduplicates using ``WebImagePickerConfiguration/similarImageDeduplication``.
 enum AggregatedPageImageDiscovery {
     struct MergeResult: Sendable {
         let images: [DiscoveredImage]
@@ -25,7 +25,10 @@ enum AggregatedPageImageDiscovery {
                     items = Array(items.prefix(cap))
                 }
                 for item in items {
-                    let key = item.sourceURL.absoluteString
+                    let key = DiscoveredImageDeduplicationKey.string(
+                        for: item.sourceURL,
+                        strategy: configuration.similarImageDeduplication
+                    )
                     guard !seenImageKeys.contains(key) else { continue }
                     seenImageKeys.insert(key)
                     merged.append(item)

--- a/Packages/WebImagePicker/Sources/WebImagePicker/SimilarImageDeduplicationStrategy.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/SimilarImageDeduplicationStrategy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// How the picker treats different URLs that may refer to the same raster asset.
+///
+/// Byte-level or perceptual hashing is not implemented yet; only URL normalization is available today.
+public enum SimilarImageDeduplicationStrategy: Sendable, Hashable {
+    /// Deduplicate using the full absolute URL string only (default). URLs that differ only by query or fragment stay distinct.
+    case disabled
+    /// Collapse URLs that share scheme, host, and path after stripping **query** and **fragment**.
+    ///
+    /// The first occurrence in discovery order is kept (including its original query string on ``DiscoveredImage/sourceURL``).
+    ///
+    /// **Tradeoff:** Some CDNs and signed URLs encode distinct variants or different images entirely in the query string. Those assets may be incorrectly merged; use ``disabled`` when queries carry resource identity.
+    case normalizedResourceURL
+}
+
+enum DiscoveredImageDeduplicationKey {
+    static func string(for url: URL, strategy: SimilarImageDeduplicationStrategy) -> String {
+        switch strategy {
+        case .disabled:
+            return url.absoluteString
+        case .normalizedResourceURL:
+            return normalizedResourceURLString(for: url)
+        }
+    }
+
+    private static func normalizedResourceURLString(for url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString
+        }
+        components.fragment = nil
+        components.query = nil
+        if let host = components.host {
+            components.host = host.lowercased()
+        }
+        if let canonical = components.url {
+            return canonical.absoluteString
+        }
+        return components.string ?? url.absoluteString
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/StaticHTMLExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/StaticHTMLExtractor.swift
@@ -53,7 +53,10 @@ public struct StaticHTMLExtractor: PageImageExtractor {
         func append(raw: String?, alt: String?) {
             guard let raw else { return }
             guard let url = normalizedURL(from: raw) else { return }
-            let key = url.absoluteString
+            let key = DiscoveredImageDeduplicationKey.string(
+                for: url,
+                strategy: configuration.similarImageDeduplication
+            )
             guard !seen.contains(key) else { return }
             seen.insert(key)
             let label = alt.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.flatMap { $0.isEmpty ? nil : $0 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -52,6 +52,9 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// When `nil` (the default), no truncation is applied. When set to a positive value, only the first N candidates from that page are kept, in the order produced by the active ``PageImageExtractor`` (see package documentation for static HTML ordering). The cap applies **per page**: in multi-URL mode, each loaded page contributes at most N images (after per-page deduplication).
     public var maximumDiscoveredImagesPerPage: Int?
 
+    /// Optional collapsing of URLs that likely name the same resource (for example cache-busting query pairs). See ``SimilarImageDeduplicationStrategy``.
+    public var similarImageDeduplication: SimilarImageDeduplicationStrategy
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -68,6 +71,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - initialURLString: Optional URL string shown in the entry field when the picker first appears.
     ///   - additionalPageURLs: Ordered extra pages to aggregate with the primary URL and any user-added URLs.
     ///   - maximumDiscoveredImagesPerPage: Optional maximum images retained per page after discovery; `nil` means unlimited.
+    ///   - similarImageDeduplication: How aggressively to merge URLs that may reference the same asset.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 10,
@@ -81,6 +85,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         initialURLString: String? = nil,
         additionalPageURLs: [URL] = [],
         maximumDiscoveredImagesPerPage: Int? = nil,
+        similarImageDeduplication: SimilarImageDeduplicationStrategy = .disabled,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -94,6 +99,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.initialURLString = initialURLString
         self.additionalPageURLs = additionalPageURLs
         self.maximumDiscoveredImagesPerPage = maximumDiscoveredImagesPerPage.flatMap { $0 > 0 ? $0 : nil }
+        self.similarImageDeduplication = similarImageDeduplication
         self.urlSession = urlSession
     }
 
@@ -111,6 +117,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             &&         lhs.initialURLString == rhs.initialURLString
             && lhs.additionalPageURLs == rhs.additionalPageURLs
             && lhs.maximumDiscoveredImagesPerPage == rhs.maximumDiscoveredImagesPerPage
+            && lhs.similarImageDeduplication == rhs.similarImageDeduplication
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -125,5 +132,6 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(initialURLString)
         hasher.combine(additionalPageURLs)
         hasher.combine(maximumDiscoveredImagesPerPage)
+        hasher.combine(similarImageDeduplication)
     }
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebViewPageImageExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebViewPageImageExtractor.swift
@@ -64,7 +64,10 @@ public struct WebViewPageImageExtractor: PageImageExtractor {
 
         for candidate in rawCandidates {
             guard let url = normalizedURL(from: candidate.value, kind: candidate.kind) else { continue }
-            let key = url.absoluteString
+            let key = DiscoveredImageDeduplicationKey.string(
+                for: url,
+                strategy: configuration.similarImageDeduplication
+            )
             guard !seen.contains(key) else { continue }
             seen.insert(key)
 

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
@@ -137,4 +137,30 @@ final class AggregatedPageImageDiscoveryTests: XCTestCase {
             [imgsA[0], imgsA[1], imgsB[0], imgsB[1]]
         )
     }
+
+    func testSimilarityDedupMergesQueryVariantsAcrossPages() async throws {
+        let a = URL(string: "https://one.example/")!
+        let b = URL(string: "https://two.example/")!
+        let wide = URL(string: "https://cdn.example.com/photo.jpg?w=800")!
+        let narrow = URL(string: "https://cdn.example.com/photo.jpg?w=400")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            a: .success([DiscoveredImage(sourceURL: wide, accessibilityLabel: "a")]),
+            b: .success([DiscoveredImage(sourceURL: narrow, accessibilityLabel: "b")]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.similarImageDeduplication = .normalizedResourceURL
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [a, b],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertTrue(merge.failedPageURLs.isEmpty)
+        XCTAssertEqual(merge.images.count, 1)
+        XCTAssertEqual(merge.images[0].sourceURL, wide)
+        XCTAssertEqual(merge.images[0].accessibilityLabel, "a")
+    }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
@@ -33,6 +33,30 @@ final class StaticHTMLExtractorTests: XCTestCase {
         XCTAssertEqual(items.count, 1)
     }
 
+    func testQueryOnlyVariantsStayDistinctWhenSimilarityDedupDisabled() throws {
+        let html = #"""
+        <img src="https://cdn.example.com/x.png?v=1" alt="first">
+        <img src="https://cdn.example.com/x.png?v=2" alt="second">
+        """#
+        let page = URL(string: "https://example.com/")!
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: defaultConfig)
+        XCTAssertEqual(items.count, 2)
+    }
+
+    func testSimilarityDedupCollapsesQueryOnlyVariants() throws {
+        let html = #"""
+        <img src="https://cdn.example.com/x.png?v=1" alt="first">
+        <img src="https://cdn.example.com/x.png?v=2" alt="second">
+        """#
+        let page = URL(string: "https://example.com/")!
+        var config = defaultConfig
+        config.similarImageDeduplication = .normalizedResourceURL
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: config)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].sourceURL.absoluteString, "https://cdn.example.com/x.png?v=1")
+        XCTAssertEqual(items[0].accessibilityLabel, "first")
+    }
+
     /// Document order for static extraction: `<img>` elements (DOM order) before Open Graph / Twitter meta images.
     func testImgElementsPrecedeOgImageInDiscoveryOrder() throws {
         let html = #"""

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -74,6 +74,16 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         XCTAssertNil(WebImagePickerConfiguration.default.maximumDiscoveredImagesPerPage)
     }
 
+    func testDefaultSimilarImageDeduplicationIsDisabled() {
+        XCTAssertEqual(WebImagePickerConfiguration.default.similarImageDeduplication, .disabled)
+    }
+
+    func testSimilarImageDeduplicationAffectsEquality() {
+        let a = WebImagePickerConfiguration(similarImageDeduplication: .disabled)
+        let b = WebImagePickerConfiguration(similarImageDeduplication: .normalizedResourceURL)
+        XCTAssertNotEqual(a, b)
+    }
+
     func testMaximumDiscoveredImagesPerPageNonPositiveBecomesNil() {
         XCTAssertNil(WebImagePickerConfiguration(maximumDiscoveredImagesPerPage: 0).maximumDiscoveredImagesPerPage)
         XCTAssertNil(WebImagePickerConfiguration(maximumDiscoveredImagesPerPage: -1).maximumDiscoveredImagesPerPage)

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebViewPageImageExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebViewPageImageExtractorTests.swift
@@ -59,4 +59,24 @@ final class WebViewPageImageExtractorTests: XCTestCase {
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results[0].sourceURL.absoluteString, "https://example.com/a.png")
     }
+
+    func testNormalizeCollapsesQueryVariantsWhenSimilarityDedupEnabled() {
+        var cfg = WebImagePickerConfiguration(allowedURLSchemes: ["https", "http"])
+        cfg.similarImageDeduplication = .normalizedResourceURL
+        let pageURL = URL(string: "https://example.com/")!
+        let candidates: [WebViewRawCandidate] = [
+            .init(value: "https://cdn.example.com/z.png?a=1", altText: "one", kind: .url),
+            .init(value: "https://cdn.example.com/z.png?b=2", altText: "two", kind: .url),
+        ]
+
+        let results = WebViewPageImageExtractor.normalize(
+            rawCandidates: candidates,
+            pageURL: pageURL,
+            configuration: cfg
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].sourceURL.absoluteString, "https://cdn.example.com/z.png?a=1")
+        XCTAssertEqual(results[0].accessibilityLabel, "one")
+    }
 }


### PR DESCRIPTION
## Summary
- Add `SimilarImageDeduplicationStrategy` (`.disabled` default, `.normalizedResourceURL` to collapse same scheme/host/path when query/fragment differ).
- Wire deduplication keys through static HTML extraction, WebView normalization, and aggregated multi-page merge.
- Document tradeoffs on the public enum; add unit tests for HTML fixtures and cross-page merge.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: all 61 tests passed

Closes #38

Made with [Cursor](https://cursor.com)