### PR TITLE
Fix #39: configurable discovered image sort before per-page cap

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
@@ -21,6 +21,7 @@ enum AggregatedPageImageDiscovery {
         for pageURL in pageURLs {
             do {
                 var items = try await extractor.discoverImages(from: pageURL, configuration: configuration)
+                items = configuration.discoveredImageSort.orderedImages(items)
                 if let cap = configuration.maximumDiscoveredImagesPerPage {
                     items = Array(items.prefix(cap))
                 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageSort.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageSort.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Sort order applied to each page’s deduplicated discovery results before ``WebImagePickerConfiguration/maximumDiscoveredImagesPerPage`` truncation and cross-page merge.
+///
+/// The default is ``discoveryOrder``, which preserves the order from the active ``PageImageExtractor`` (DOM order for static HTML). Sorting uses a stable tie-break on original discovery index when comparison keys match.
+public enum DiscoveredImageSort: Sendable, Hashable {
+    /// Preserve extractor order (no reordering).
+    case discoveryOrder
+
+    /// Lexicographic ascending on ``DiscoveredImage/sourceURL`` (`absoluteString`, UTF-8 code units).
+    case sourceURLAscending
+
+    /// Descending inferred pixel width from URL query parameters `w` or `width` (first positive integer wins). Unknown width sorts as `0` (after positive widths). This approximates “largest srcset candidate” when dimensions are reflected in the URL, not from raw `srcset` text (which is not retained on ``DiscoveredImage``).
+    case inferredPixelWidthDescending
+
+    /// Portrait-like URLs first, then unknown or square, then landscape, using `w`/`width` and `h`/`height` query integers when both exist. URLs missing either dimension go in the middle bucket (same as square).
+    case aspectRatioBucketPortraitFirst
+
+    func orderedImages(_ images: [DiscoveredImage]) -> [DiscoveredImage] {
+        switch self {
+        case .discoveryOrder:
+            return images
+        case .sourceURLAscending:
+            return images.enumerated().sorted { lhs, rhs in
+                let l = lhs.element.sourceURL.absoluteString
+                let r = rhs.element.sourceURL.absoluteString
+                if l != r { return l < r }
+                return lhs.offset < rhs.offset
+            }.map(\.element)
+        case .inferredPixelWidthDescending:
+            return images.enumerated().sorted { lhs, rhs in
+                let lw = Self.pixelWidthHint(for: lhs.element.sourceURL)
+                let rw = Self.pixelWidthHint(for: rhs.element.sourceURL)
+                if lw != rw { return lw > rw }
+                return lhs.offset < rhs.offset
+            }.map(\.element)
+        case .aspectRatioBucketPortraitFirst:
+            return images.enumerated().sorted { lhs, rhs in
+                let lb = Self.aspectRatioBucket(for: lhs.element.sourceURL)
+                let rb = Self.aspectRatioBucket(for: rhs.element.sourceURL)
+                if lb != rb { return lb < rb }
+                return lhs.offset < rhs.offset
+            }.map(\.element)
+        }
+    }
+
+    private static func pixelWidthHint(for url: URL) -> Int {
+        guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
+            return 0
+        }
+        for name in ["w", "width"] {
+            if let raw = items.first(where: { $0.name.lowercased() == name })?.value,
+               let n = Int(raw), n > 0 {
+                return n
+            }
+        }
+        return 0
+    }
+
+    /// 0 = portrait, 1 = square or unknown, 2 = landscape
+    private static func aspectRatioBucket(for url: URL) -> Int {
+        guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
+            return 1
+        }
+        func positiveInt(names: [String]) -> Int? {
+            for name in names {
+                if let raw = items.first(where: { $0.name.lowercased() == name })?.value,
+                   let n = Int(raw), n > 0 {
+                    return n
+                }
+            }
+            return nil
+        }
+        guard let w = positiveInt(names: ["w", "width"]),
+              let h = positiveInt(names: ["h", "height"]) else {
+            return 1
+        }
+        let ratio = Double(w) / Double(h)
+        if ratio < 0.95 { return 0 }
+        if ratio <= 1.05 { return 1 }
+        return 2
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -49,8 +49,11 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
 
     /// Upper bound on how many images to keep from each page after discovery, before they are merged into the grid.
     ///
-    /// When `nil` (the default), no truncation is applied. When set to a positive value, only the first N candidates from that page are kept, in the order produced by the active ``PageImageExtractor`` (see package documentation for static HTML ordering). The cap applies **per page**: in multi-URL mode, each loaded page contributes at most N images (after per-page deduplication).
+    /// When `nil` (the default), no truncation is applied. When set to a positive value, only the first N candidates from that page are kept **after** ``discoveredImageSort`` is applied (default ``DiscoveredImageSort/discoveryOrder`` matches extractor order; see package documentation for static HTML ordering). The cap applies **per page**: in multi-URL mode, each loaded page contributes at most N images (after per-page deduplication).
     public var maximumDiscoveredImagesPerPage: Int?
+
+    /// How to order each page’s deduplicated images before ``maximumDiscoveredImagesPerPage`` truncation. Default ``DiscoveredImageSort/discoveryOrder`` preserves extractor order.
+    public var discoveredImageSort: DiscoveredImageSort
 
     /// Optional collapsing of URLs that likely name the same resource (for example cache-busting query pairs). See ``SimilarImageDeduplicationStrategy``.
     public var similarImageDeduplication: SimilarImageDeduplicationStrategy
@@ -71,6 +74,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - initialURLString: Optional URL string shown in the entry field when the picker first appears.
     ///   - additionalPageURLs: Ordered extra pages to aggregate with the primary URL and any user-added URLs.
     ///   - maximumDiscoveredImagesPerPage: Optional maximum images retained per page after discovery; `nil` means unlimited.
+    ///   - discoveredImageSort: Order applied per page after deduplication and before the per-page cap.
     ///   - similarImageDeduplication: How aggressively to merge URLs that may reference the same asset.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
@@ -85,6 +89,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         initialURLString: String? = nil,
         additionalPageURLs: [URL] = [],
         maximumDiscoveredImagesPerPage: Int? = nil,
+        discoveredImageSort: DiscoveredImageSort = .discoveryOrder,
         similarImageDeduplication: SimilarImageDeduplicationStrategy = .disabled,
         urlSession: URLSession = .shared
     ) {
@@ -99,6 +104,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.initialURLString = initialURLString
         self.additionalPageURLs = additionalPageURLs
         self.maximumDiscoveredImagesPerPage = maximumDiscoveredImagesPerPage.flatMap { $0 > 0 ? $0 : nil }
+        self.discoveredImageSort = discoveredImageSort
         self.similarImageDeduplication = similarImageDeduplication
         self.urlSession = urlSession
     }
@@ -114,9 +120,10 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.maximumHTMLDownloadBytes == rhs.maximumHTMLDownloadBytes
             && lhs.maximumImageDownloadBytes == rhs.maximumImageDownloadBytes
             && lhs.extractionMode == rhs.extractionMode
-            &&         lhs.initialURLString == rhs.initialURLString
+            && lhs.initialURLString == rhs.initialURLString
             && lhs.additionalPageURLs == rhs.additionalPageURLs
             && lhs.maximumDiscoveredImagesPerPage == rhs.maximumDiscoveredImagesPerPage
+            && lhs.discoveredImageSort == rhs.discoveredImageSort
             && lhs.similarImageDeduplication == rhs.similarImageDeduplication
     }
 
@@ -132,6 +139,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(initialURLString)
         hasher.combine(additionalPageURLs)
         hasher.combine(maximumDiscoveredImagesPerPage)
+        hasher.combine(discoveredImageSort)
         hasher.combine(similarImageDeduplication)
     }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
@@ -138,6 +138,88 @@ final class AggregatedPageImageDiscoveryTests: XCTestCase {
         )
     }
 
+    func testSourceURLAscendingSortRunsBeforePerPageCap() async throws {
+        let page = URL(string: "https://one.example/")!
+        let zebra = URL(string: "https://cdn.example/z.png")!
+        let alpha = URL(string: "https://cdn.example/a.png")!
+        let beta = URL(string: "https://cdn.example/b.png")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            page: .success([
+                DiscoveredImage(sourceURL: zebra, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: beta, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: alpha, accessibilityLabel: nil),
+            ]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.discoveredImageSort = .sourceURLAscending
+        config.maximumDiscoveredImagesPerPage = 2
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [page],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertTrue(merge.failedPageURLs.isEmpty)
+        XCTAssertEqual(merge.images.map(\.sourceURL), [alpha, beta])
+    }
+
+    func testInferredPixelWidthDescendingSortBeforeCap() async throws {
+        let page = URL(string: "https://one.example/")!
+        let narrow = URL(string: "https://cdn.example/n.jpg?w=400")!
+        let wide = URL(string: "https://cdn.example/w.jpg?w=1200")!
+        let mid = URL(string: "https://cdn.example/m.jpg?width=800")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            page: .success([
+                DiscoveredImage(sourceURL: narrow, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: mid, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: wide, accessibilityLabel: nil),
+            ]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.discoveredImageSort = .inferredPixelWidthDescending
+        config.maximumDiscoveredImagesPerPage = 2
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [page],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertEqual(merge.images.map(\.sourceURL), [wide, mid])
+    }
+
+    func testAspectRatioBucketPortraitFirstOrdersBeforeCap() async throws {
+        let page = URL(string: "https://one.example/")!
+        let landscape = URL(string: "https://cdn.example/l.jpg?w=1200&h=400")!
+        let portrait = URL(string: "https://cdn.example/p.jpg?w=400&h=1200")!
+        let square = URL(string: "https://cdn.example/s.jpg?w=500&h=500")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            page: .success([
+                DiscoveredImage(sourceURL: landscape, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: square, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: portrait, accessibilityLabel: nil),
+            ]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.discoveredImageSort = .aspectRatioBucketPortraitFirst
+        config.maximumDiscoveredImagesPerPage = 2
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [page],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertEqual(merge.images.map(\.sourceURL), [portrait, square])
+    }
+
     func testSimilarityDedupMergesQueryVariantsAcrossPages() async throws {
         let a = URL(string: "https://one.example/")!
         let b = URL(string: "https://two.example/")!

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -78,6 +78,16 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         XCTAssertEqual(WebImagePickerConfiguration.default.similarImageDeduplication, .disabled)
     }
 
+    func testDefaultDiscoveredImageSortIsDiscoveryOrder() {
+        XCTAssertEqual(WebImagePickerConfiguration.default.discoveredImageSort, .discoveryOrder)
+    }
+
+    func testDiscoveredImageSortAffectsEquality() {
+        let a = WebImagePickerConfiguration(discoveredImageSort: .discoveryOrder)
+        let b = WebImagePickerConfiguration(discoveredImageSort: .sourceURLAscending)
+        XCTAssertNotEqual(a, b)
+    }
+
     func testSimilarImageDeduplicationAffectsEquality() {
         let a = WebImagePickerConfiguration(similarImageDeduplication: .disabled)
         let b = WebImagePickerConfiguration(similarImageDeduplication: .normalizedResourceURL)


### PR DESCRIPTION
## Summary
- Add `DiscoveredImageSort` (discovery order default, URL lexicographic, inferred width from URL query, aspect-ratio buckets from w×h query).
- Wire `WebImagePickerConfiguration.discoveredImageSort` into `AggregatedPageImageDiscovery` so sorting runs after per-page extraction/dedup and before `maximumDiscoveredImagesPerPage` truncation.
- Tests cover lexicographic + width strategies (and aspect bucket); config defaults and equality updated.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: all 66 tests passed

Closes #39

Made with [Cursor](https://cursor.com)