### PR TITLE
Fix #41: allowlist image types by UTType and Content-Type

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
@@ -22,6 +22,7 @@ enum AggregatedPageImageDiscovery {
             do {
                 var items = try await extractor.discoverImages(from: pageURL, configuration: configuration)
                 items = configuration.discoveredImageSort.orderedImages(items)
+                items = items.filter { ImageTypeAllowlist.passesDiscovery(url: $0.sourceURL, configuration: configuration) }
                 items = await DiscoveredImageDimensionFiltering.filtered(images: items, configuration: configuration)
                 if let cap = configuration.maximumDiscoveredImagesPerPage {
                     items = Array(items.prefix(cap))

--- a/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService.swift
@@ -16,6 +16,9 @@ enum ImageDownloadService {
             throw WebImagePickerError.imageTooLarge
         }
         let contentType = http.value(forHTTPHeaderField: "Content-Type")
+        guard ImageTypeAllowlist.passesDownload(contentTypeHeader: contentType, configuration: configuration) else {
+            throw WebImagePickerError.unsupportedImageType
+        }
         return WebImageSelection(data: data, contentType: contentType, sourceURL: url)
     }
 

--- a/Packages/WebImagePicker/Sources/WebImagePicker/ImageTypeAllowlist.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/ImageTypeAllowlist.swift
@@ -1,0 +1,70 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Filters discovered image URLs by path extension and completed downloads by `Content-Type`, using ``WebImagePickerConfiguration/allowedImageTypeIdentifiers`` as `UTType` identifiers (for example ``UTType/jpeg`` `.identifier`).
+enum ImageTypeAllowlist {
+    static func isFilteringEnabled(for configuration: WebImagePickerConfiguration) -> Bool {
+        guard let ids = configuration.allowedImageTypeIdentifiers, !ids.isEmpty else { return false }
+        return true
+    }
+
+    private static func resolvedAllowedTypes(for configuration: WebImagePickerConfiguration) -> [UTType] {
+        guard let ids = configuration.allowedImageTypeIdentifiers else { return [] }
+        return ids.compactMap { UTType($0) }
+    }
+
+    /// Discovery-time filter using the URL’s path extension.
+    static func passesDiscovery(url: URL, configuration: WebImagePickerConfiguration) -> Bool {
+        guard isFilteringEnabled(for: configuration) else { return true }
+
+        let ext = url.pathExtension.lowercased()
+        if ext.isEmpty {
+            return configuration.unknownImageTypePolicy == .allow
+        }
+
+        guard let inferred = UTType(filenameExtension: ext) else {
+            return configuration.unknownImageTypePolicy == .allow
+        }
+
+        if !inferred.conforms(to: .image) {
+            return false
+        }
+
+        return matchesAllowlist(imageType: inferred, configuration: configuration)
+    }
+
+    /// Download-time filter using the response `Content-Type` header (parameters such as `charset` are ignored).
+    static func passesDownload(contentTypeHeader: String?, configuration: WebImagePickerConfiguration) -> Bool {
+        guard isFilteringEnabled(for: configuration) else { return true }
+
+        let mime = contentTypeHeader?
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
+            .first
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+
+        guard let mime, !mime.isEmpty else {
+            return configuration.unknownImageTypePolicy == .allow
+        }
+
+        guard let inferred = UTType(mimeType: mime) else {
+            return configuration.unknownImageTypePolicy == .allow
+        }
+
+        if !inferred.conforms(to: .image) {
+            return false
+        }
+
+        return matchesAllowlist(imageType: inferred, configuration: configuration)
+    }
+
+    private static func matchesAllowlist(imageType: UTType, configuration: WebImagePickerConfiguration) -> Bool {
+        let allowed = resolvedAllowedTypes(for: configuration)
+        if allowed.isEmpty {
+            return true
+        }
+        for a in allowed where imageType.conforms(to: a) {
+            return true
+        }
+        return false
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/Resources/en.lproj/Localizable.strings
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/Resources/en.lproj/Localizable.strings
@@ -3,6 +3,7 @@
 "webimage.changeURL" = "Change URL";
 "webimage.done" = "Done";
 "webimage.error.downloadFailed" = "Could not download an image.";
+"webimage.error.unsupportedImageType" = "This image type is not allowed.";
 "webimage.error.enterValidURL" = "Enter a valid URL.";
 "webimage.error.extractionFailed" = "Could not read images from this page.";
 "webimage.error.generic" = "Something went wrong.";

--- a/Packages/WebImagePicker/Sources/WebImagePicker/Resources/es.lproj/Localizable.strings
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/Resources/es.lproj/Localizable.strings
@@ -3,6 +3,7 @@
 "webimage.changeURL" = "Cambiar URL";
 "webimage.done" = "Listo";
 "webimage.error.downloadFailed" = "No se pudo descargar una imagen.";
+"webimage.error.unsupportedImageType" = "Este tipo de imagen no está permitido.";
 "webimage.error.enterValidURL" = "Introduce una URL válida.";
 "webimage.error.extractionFailed" = "No se pudieron leer las imágenes de esta página.";
 "webimage.error.generic" = "Algo salió mal.";

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -65,6 +65,12 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// Optional maximum pixel width and height. When non-`nil`, a component `<= 0` means no maximum on that axis. Applied after discovery sort and before ``maximumDiscoveredImagesPerPage`` using a lightweight ranged GET per candidate (see ``DiscoveredImageDimensionFiltering``).
     public var maximumImageDimensions: CGSize?
 
+    /// Allowed image formats as `UTType` identifier strings (for example ``UTType/jpeg`` `.identifier`). When `nil` or empty, discovery and downloads do not filter by type. When non-empty, URLs whose extension maps to a non-image type are dropped; image types must conform to at least one listed type. Extension-less URLs follow ``unknownImageTypePolicy``.
+    public var allowedImageTypeIdentifiers: Set<String>?
+
+    /// When ``allowedImageTypeIdentifiers`` is active, controls handling of types that cannot be inferred from the URL or from `Content-Type`. Default ``WebImageUnknownTypePolicy/allow``.
+    public var unknownImageTypePolicy: WebImageUnknownTypePolicy
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -85,6 +91,8 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - similarImageDeduplication: How aggressively to merge URLs that may reference the same asset.
     ///   - minimumImageDimensions: Optional lower pixel bounds per axis (`<= 0` on an axis disables that side).
     ///   - maximumImageDimensions: Optional upper pixel bounds per axis (`<= 0` on an axis disables that side).
+    ///   - allowedImageTypeIdentifiers: Optional `UTType` identifier allowlist; `nil` or empty disables type filtering.
+    ///   - unknownImageTypePolicy: Behavior for unknown types when an allowlist is active.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 10,
@@ -102,6 +110,8 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         similarImageDeduplication: SimilarImageDeduplicationStrategy = .disabled,
         minimumImageDimensions: CGSize? = nil,
         maximumImageDimensions: CGSize? = nil,
+        allowedImageTypeIdentifiers: Set<String>? = nil,
+        unknownImageTypePolicy: WebImageUnknownTypePolicy = .allow,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -119,6 +129,8 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.similarImageDeduplication = similarImageDeduplication
         self.minimumImageDimensions = minimumImageDimensions
         self.maximumImageDimensions = maximumImageDimensions
+        self.allowedImageTypeIdentifiers = allowedImageTypeIdentifiers.flatMap { $0.isEmpty ? nil : $0 }
+        self.unknownImageTypePolicy = unknownImageTypePolicy
         self.urlSession = urlSession
     }
 
@@ -140,6 +152,8 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.similarImageDeduplication == rhs.similarImageDeduplication
             && lhs.minimumImageDimensions == rhs.minimumImageDimensions
             && lhs.maximumImageDimensions == rhs.maximumImageDimensions
+            && lhs.allowedImageTypeIdentifiers == rhs.allowedImageTypeIdentifiers
+            && lhs.unknownImageTypePolicy == rhs.unknownImageTypePolicy
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -158,6 +172,8 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(similarImageDeduplication)
         Self.hashCGSizeOptional(minimumImageDimensions, into: &hasher)
         Self.hashCGSizeOptional(maximumImageDimensions, into: &hasher)
+        hasher.combine(allowedImageTypeIdentifiers)
+        hasher.combine(unknownImageTypePolicy)
     }
 
     private static func hashCGSizeOptional(_ size: CGSize?, into hasher: inout Hasher) {

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerError.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerError.swift
@@ -9,4 +9,6 @@ public enum WebImagePickerError: Error, Sendable, Equatable {
     case noImagesFound
     case imageTooLarge
     case downloadFailed
+    /// Response `Content-Type` is not allowed by ``WebImagePickerConfiguration/allowedImageTypeIdentifiers`` (or is missing when ``WebImagePickerConfiguration/unknownImageTypePolicy`` is ``WebImageUnknownTypePolicy/reject``).
+    case unsupportedImageType
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
@@ -250,6 +250,11 @@ final class WebImagePickerViewModel {
                     localized: String.LocalizationValue("webimage.error.downloadFailed"),
                     bundle: WebImagePickerBundle.module
                 )
+            case .unsupportedImageType:
+                return String(
+                    localized: String.LocalizationValue("webimage.error.unsupportedImageType"),
+                    bundle: WebImagePickerBundle.module
+                )
             }
         }
         return String(

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImageUnknownTypePolicy.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImageUnknownTypePolicy.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Policy when an image’s type cannot be inferred from the URL path or from HTTP `Content-Type` while an allowlist is active.
+public enum WebImageUnknownTypePolicy: Sendable, Hashable {
+    /// Keep discovery candidates and allow downloads when the type is unknown (for example extension-less URLs or servers that omit `Content-Type`).
+    case allow
+    /// Drop extension-less or unmapped discovery URLs; fail downloads when `Content-Type` is missing or cannot be mapped to an image type.
+    case reject
+}

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
@@ -1,3 +1,4 @@
+import UniformTypeIdentifiers
 import XCTest
 @testable import WebImagePicker
 
@@ -218,6 +219,31 @@ final class AggregatedPageImageDiscoveryTests: XCTestCase {
         )
 
         XCTAssertEqual(merge.images.map(\.sourceURL), [portrait, square])
+    }
+
+    func testAllowlistedImageTypesFilterDiscoveredURLs() async throws {
+        let page = URL(string: "https://one.example/")!
+        let jpg = URL(string: "https://cdn.example/a.jpg")!
+        let png = URL(string: "https://cdn.example/b.png")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            page: .success([
+                DiscoveredImage(sourceURL: jpg, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: png, accessibilityLabel: nil),
+            ]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.allowedImageTypeIdentifiers = [UTType.jpeg.identifier]
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [page],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertTrue(merge.failedPageURLs.isEmpty)
+        XCTAssertEqual(merge.images.map(\.sourceURL), [jpg])
     }
 
     func testSimilarityDedupMergesQueryVariantsAcrossPages() async throws {

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/ImageTypeAllowlistTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/ImageTypeAllowlistTests.swift
@@ -1,0 +1,76 @@
+import UniformTypeIdentifiers
+import XCTest
+@testable import WebImagePicker
+
+final class ImageTypeAllowlistTests: XCTestCase {
+    private var jpegOnly: WebImagePickerConfiguration {
+        var c = WebImagePickerConfiguration.default
+        c.allowedImageTypeIdentifiers = [UTType.jpeg.identifier]
+        return c
+    }
+
+    func testDiscoveryAllowsJPEGWhenJPEGAllowlisted() {
+        let u = URL(string: "https://cdn.example/a.jpg")!
+        XCTAssertTrue(ImageTypeAllowlist.passesDiscovery(url: u, configuration: jpegOnly))
+    }
+
+    func testDiscoveryDropsPNGWhenOnlyJPEGAllowlisted() {
+        let u = URL(string: "https://cdn.example/a.png")!
+        XCTAssertFalse(ImageTypeAllowlist.passesDiscovery(url: u, configuration: jpegOnly))
+    }
+
+    func testDiscoveryDropsNonImageExtension() {
+        let u = URL(string: "https://cdn.example/doc.html")!
+        XCTAssertFalse(ImageTypeAllowlist.passesDiscovery(url: u, configuration: jpegOnly))
+    }
+
+    func testDiscoveryExtensionlessAllowsWhenPolicyAllow() {
+        let u = URL(string: "https://cdn.example/resize/123")!
+        XCTAssertTrue(ImageTypeAllowlist.passesDiscovery(url: u, configuration: jpegOnly))
+    }
+
+    func testDiscoveryExtensionlessRejectsWhenPolicyReject() {
+        var c = jpegOnly
+        c.unknownImageTypePolicy = .reject
+        let u = URL(string: "https://cdn.example/resize/123")!
+        XCTAssertFalse(ImageTypeAllowlist.passesDiscovery(url: u, configuration: c))
+    }
+
+    func testDiscoveryPublicImageIdentifierAllowsJPEG() {
+        var c = WebImagePickerConfiguration.default
+        c.allowedImageTypeIdentifiers = [UTType.image.identifier]
+        let u = URL(string: "https://cdn.example/a.jpg")!
+        XCTAssertTrue(ImageTypeAllowlist.passesDiscovery(url: u, configuration: c))
+    }
+
+    func testDownloadPNGRejectedWhenOnlyJPEGAllowlisted() {
+        XCTAssertFalse(ImageTypeAllowlist.passesDownload(contentTypeHeader: "image/png", configuration: jpegOnly))
+    }
+
+    func testDownloadJPEGPassesWhenJPEGAllowlisted() {
+        XCTAssertTrue(ImageTypeAllowlist.passesDownload(contentTypeHeader: "image/jpeg", configuration: jpegOnly))
+    }
+
+    func testDownloadParsesMimeWithCharset() {
+        XCTAssertTrue(ImageTypeAllowlist.passesDownload(contentTypeHeader: "image/jpeg; charset=binary", configuration: jpegOnly))
+    }
+
+    func testDownloadMissingTypeAllowsWhenPolicyAllow() {
+        XCTAssertTrue(ImageTypeAllowlist.passesDownload(contentTypeHeader: nil, configuration: jpegOnly))
+    }
+
+    func testDownloadMissingTypeRejectsWhenPolicyReject() {
+        var c = jpegOnly
+        c.unknownImageTypePolicy = .reject
+        XCTAssertFalse(ImageTypeAllowlist.passesDownload(contentTypeHeader: nil, configuration: c))
+    }
+
+    func testNoAllowlistPassesArbitraryDiscovery() {
+        let u = URL(string: "https://cdn.example/a.gif")!
+        XCTAssertTrue(ImageTypeAllowlist.passesDiscovery(url: u, configuration: .default))
+    }
+
+    func testNoAllowlistPassesArbitraryDownloadMime() {
+        XCTAssertTrue(ImageTypeAllowlist.passesDownload(contentTypeHeader: "image/webp", configuration: .default))
+    }
+}

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/InjectableURLSessionTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/InjectableURLSessionTests.swift
@@ -1,3 +1,4 @@
+import UniformTypeIdentifiers
 import XCTest
 @testable import WebImagePicker
 
@@ -97,5 +98,31 @@ final class InjectableURLSessionTests: XCTestCase {
         XCTAssertEqual(selection.data, payload)
         XCTAssertEqual(selection.contentType, "image/jpeg")
         XCTAssertEqual(selection.sourceURL, imageURL)
+    }
+
+    func testImageDownloadServiceRejectsDisallowedContentType() async throws {
+        let imageURL = URL(string: "https://example.com/photo.bin")!
+        let payload = Data([0x00, 0x01])
+        StubURLProtocol.setHandler { request in
+            XCTAssertEqual(request.url, imageURL)
+            let response = HTTPURLResponse(
+                url: imageURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, payload)
+        }
+
+        var config = WebImagePickerConfiguration(allowedURLSchemes: ["https"])
+        config.allowedImageTypeIdentifiers = [UTType.jpeg.identifier]
+        config.urlSession = urlSessionWithStub()
+
+        do {
+            _ = try await ImageDownloadService.download(from: imageURL, configuration: config)
+            XCTFail("expected unsupportedImageType")
+        } catch let error as WebImagePickerError {
+            XCTAssertEqual(error, .unsupportedImageType)
+        }
     }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import UniformTypeIdentifiers
 import XCTest
 @testable import WebImagePicker
 
@@ -87,6 +88,30 @@ final class WebImagePickerConfigurationTests: XCTestCase {
     func testImageDimensionBoundsAffectEquality() {
         let a = WebImagePickerConfiguration(minimumImageDimensions: CGSize(width: 10, height: 10))
         let b = WebImagePickerConfiguration(minimumImageDimensions: CGSize(width: 11, height: 10))
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testDefaultAllowedImageTypeIdentifiersNil() {
+        XCTAssertNil(WebImagePickerConfiguration.default.allowedImageTypeIdentifiers)
+    }
+
+    func testDefaultUnknownImageTypePolicyAllow() {
+        XCTAssertEqual(WebImagePickerConfiguration.default.unknownImageTypePolicy, .allow)
+    }
+
+    func testEmptyImageTypeAllowlistNormalizedToNil() {
+        XCTAssertNil(WebImagePickerConfiguration(allowedImageTypeIdentifiers: []).allowedImageTypeIdentifiers)
+    }
+
+    func testImageTypeAllowlistAffectsEquality() {
+        let a = WebImagePickerConfiguration(allowedImageTypeIdentifiers: [UTType.jpeg.identifier])
+        let b = WebImagePickerConfiguration(allowedImageTypeIdentifiers: [UTType.png.identifier])
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testUnknownImageTypePolicyAffectsEquality() {
+        let a = WebImagePickerConfiguration(unknownImageTypePolicy: .allow)
+        let b = WebImagePickerConfiguration(unknownImageTypePolicy: .reject)
         XCTAssertNotEqual(a, b)
     }
 

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerViewModelUserMessageTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerViewModelUserMessageTests.swift
@@ -13,6 +13,7 @@ final class WebImagePickerViewModelUserMessageTests: XCTestCase {
             .noImagesFound,
             .imageTooLarge,
             .downloadFailed,
+            .unsupportedImageType,
         ]
         var seen = Set<String>()
         for err in cases {


### PR DESCRIPTION
## Summary
- Add `allowedImageTypeIdentifiers` (`Set<String>?` of `UTType` identifiers) and `unknownImageTypePolicy` (`WebImageUnknownTypePolicy`) to `WebImagePickerConfiguration`; empty set normalizes to `nil` (no filtering).
- Filter discovery candidates after sort (before dimension probes) using URL path extensions and `UTType`; non-image extensions are dropped when an allowlist is active.
- Validate each download against parsed `Content-Type`; failures throw `WebImagePickerError.unsupportedImageType` with new localized strings (en/es).

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: 94 tests passed; `swift build` clean

Closes #41

Made with [Cursor](https://cursor.com)