### PR TITLE
Fix #42: configurable selection output (data, validated bitmap, temp file)

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService+SelectionOutput.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService+SelectionOutput.swift
@@ -1,0 +1,60 @@
+import Foundation
+import UniformTypeIdentifiers
+
+#if canImport(UIKit)
+import UIKit
+#endif
+#if os(macOS)
+import AppKit
+#endif
+
+extension ImageDownloadService {
+    static func makeSelection(
+        data: Data,
+        contentType: String?,
+        sourceURL: URL,
+        configuration: WebImagePickerConfiguration
+    ) throws -> WebImageSelection {
+        switch configuration.selectionOutputMode {
+        case .dataOnly:
+            return WebImageSelection(data: data, contentType: contentType, sourceURL: sourceURL, temporaryFileURL: nil)
+
+        case .platformImage:
+            #if canImport(UIKit)
+            guard UIImage(data: data) != nil else {
+                throw WebImagePickerError.imageDecodeFailed
+            }
+            #elseif os(macOS)
+            guard NSImage(data: data) != nil else {
+                throw WebImagePickerError.imageDecodeFailed
+            }
+            #else
+            throw WebImagePickerError.imageDecodeFailed
+            #endif
+            return WebImageSelection(data: data, contentType: contentType, sourceURL: sourceURL, temporaryFileURL: nil)
+
+        case .temporaryFileURL:
+            let ext = Self.filenameExtensionHint(contentType: contentType, sourceURL: sourceURL)
+            let dest = FileManager.default.temporaryDirectory
+                .appendingPathComponent("WebImagePicker-\(UUID().uuidString)", isDirectory: false)
+                .appendingPathExtension(ext)
+            try data.write(to: dest, options: .atomic)
+            return WebImageSelection(data: Data(), contentType: contentType, sourceURL: sourceURL, temporaryFileURL: dest)
+        }
+    }
+
+    private static func filenameExtensionHint(contentType: String?, sourceURL: URL) -> String {
+        let mime = contentType?
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
+            .first
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        if let mime, let ut = UTType(mimeType: mime), let pref = ut.preferredFilenameExtension, !pref.isEmpty {
+            return pref
+        }
+        let pathExt = sourceURL.pathExtension.lowercased()
+        if !pathExt.isEmpty {
+            return pathExt
+        }
+        return "bin"
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/ImageDownloadService.swift
@@ -19,7 +19,7 @@ enum ImageDownloadService {
         guard ImageTypeAllowlist.passesDownload(contentTypeHeader: contentType, configuration: configuration) else {
             throw WebImagePickerError.unsupportedImageType
         }
-        return WebImageSelection(data: data, contentType: contentType, sourceURL: url)
+        return try makeSelection(data: data, contentType: contentType, sourceURL: url, configuration: configuration)
     }
 
     static func downloadSelections(

--- a/Packages/WebImagePicker/Sources/WebImagePicker/Resources/en.lproj/Localizable.strings
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/Resources/en.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "webimage.done" = "Done";
 "webimage.error.downloadFailed" = "Could not download an image.";
 "webimage.error.unsupportedImageType" = "This image type is not allowed.";
+"webimage.error.imageDecodeFailed" = "Downloaded data could not be decoded as an image.";
 "webimage.error.enterValidURL" = "Enter a valid URL.";
 "webimage.error.extractionFailed" = "Could not read images from this page.";
 "webimage.error.generic" = "Something went wrong.";

--- a/Packages/WebImagePicker/Sources/WebImagePicker/Resources/es.lproj/Localizable.strings
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/Resources/es.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "webimage.done" = "Listo";
 "webimage.error.downloadFailed" = "No se pudo descargar una imagen.";
 "webimage.error.unsupportedImageType" = "Este tipo de imagen no está permitido.";
+"webimage.error.imageDecodeFailed" = "Los datos descargados no se pudieron decodificar como imagen.";
 "webimage.error.enterValidURL" = "Introduce una URL válida.";
 "webimage.error.extractionFailed" = "No se pudieron leer las imágenes de esta página.";
 "webimage.error.generic" = "Algo salió mal.";

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -71,6 +71,9 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// When ``allowedImageTypeIdentifiers`` is active, controls handling of types that cannot be inferred from the URL or from `Content-Type`. Default ``WebImageUnknownTypePolicy/allow``.
     public var unknownImageTypePolicy: WebImageUnknownTypePolicy
 
+    /// How completed downloads are exposed in ``WebImageSelection`` (default ``WebImageSelectionOutputMode/dataOnly``).
+    public var selectionOutputMode: WebImageSelectionOutputMode
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -93,6 +96,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - maximumImageDimensions: Optional upper pixel bounds per axis (`<= 0` on an axis disables that side).
     ///   - allowedImageTypeIdentifiers: Optional `UTType` identifier allowlist; `nil` or empty disables type filtering.
     ///   - unknownImageTypePolicy: Behavior for unknown types when an allowlist is active.
+    ///   - selectionOutputMode: How ``WebImageSelection`` values are filled after download.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 10,
@@ -112,6 +116,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         maximumImageDimensions: CGSize? = nil,
         allowedImageTypeIdentifiers: Set<String>? = nil,
         unknownImageTypePolicy: WebImageUnknownTypePolicy = .allow,
+        selectionOutputMode: WebImageSelectionOutputMode = .dataOnly,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -131,6 +136,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.maximumImageDimensions = maximumImageDimensions
         self.allowedImageTypeIdentifiers = allowedImageTypeIdentifiers.flatMap { $0.isEmpty ? nil : $0 }
         self.unknownImageTypePolicy = unknownImageTypePolicy
+        self.selectionOutputMode = selectionOutputMode
         self.urlSession = urlSession
     }
 
@@ -154,6 +160,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.maximumImageDimensions == rhs.maximumImageDimensions
             && lhs.allowedImageTypeIdentifiers == rhs.allowedImageTypeIdentifiers
             && lhs.unknownImageTypePolicy == rhs.unknownImageTypePolicy
+            && lhs.selectionOutputMode == rhs.selectionOutputMode
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -174,6 +181,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         Self.hashCGSizeOptional(maximumImageDimensions, into: &hasher)
         hasher.combine(allowedImageTypeIdentifiers)
         hasher.combine(unknownImageTypePolicy)
+        hasher.combine(selectionOutputMode)
     }
 
     private static func hashCGSizeOptional(_ size: CGSize?, into hasher: inout Hasher) {

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerError.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerError.swift
@@ -11,4 +11,6 @@ public enum WebImagePickerError: Error, Sendable, Equatable {
     case downloadFailed
     /// Response `Content-Type` is not allowed by ``WebImagePickerConfiguration/allowedImageTypeIdentifiers`` (or is missing when ``WebImagePickerConfiguration/unknownImageTypePolicy`` is ``WebImageUnknownTypePolicy/reject``).
     case unsupportedImageType
+    /// Payload could not be decoded as a platform image while ``WebImagePickerConfiguration/selectionOutputMode`` is ``WebImageSelectionOutputMode/platformImage``.
+    case imageDecodeFailed
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
@@ -255,6 +255,11 @@ final class WebImagePickerViewModel {
                     localized: String.LocalizationValue("webimage.error.unsupportedImageType"),
                     bundle: WebImagePickerBundle.module
                 )
+            case .imageDecodeFailed:
+                return String(
+                    localized: String.LocalizationValue("webimage.error.imageDecodeFailed"),
+                    bundle: WebImagePickerBundle.module
+                )
             }
         }
         return String(

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelection+PlatformImage.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelection+PlatformImage.swift
@@ -6,7 +6,10 @@ import UIKit
 extension WebImageSelection {
     /// Decodes the downloaded bytes as a `UIImage` when possible.
     public func makeUIImage() -> UIImage? {
-        UIImage(data: data)
+        if data.isEmpty, let temp = temporaryFileURL, let fileData = try? Data(contentsOf: temp) {
+            return UIImage(data: fileData)
+        }
+        return UIImage(data: data)
     }
 }
 #endif
@@ -17,7 +20,10 @@ import AppKit
 extension WebImageSelection {
     /// Decodes the downloaded bytes as an `NSImage` when possible.
     public func makeNSImage() -> NSImage? {
-        NSImage(data: data)
+        if data.isEmpty, let temp = temporaryFileURL, let fileData = try? Data(contentsOf: temp) {
+            return NSImage(data: fileData)
+        }
+        return NSImage(data: data)
     }
 }
 #endif

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelection.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelection.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A downloaded image chosen by the user, including raw bytes and metadata.
 ///
-/// Decode with ``makeUIImage()`` on iOS, tvOS, or visionOS, or ``makeNSImage()`` on macOS when those APIs are available.
+/// Decode with ``makeUIImage()`` on iOS, tvOS, or visionOS, or ``makeNSImage()`` on macOS when those APIs are available. When ``temporaryFileURL`` is set (``WebImageSelectionOutputMode/temporaryFileURL``), ``data`` is typically empty and bitmap helpers read from that file.
 public struct WebImageSelection: Sendable, Hashable {
     /// Raw image bytes returned by the network response.
     public let data: Data
@@ -10,11 +10,14 @@ public struct WebImageSelection: Sendable, Hashable {
     public let contentType: String?
     /// Absolute URL of the downloaded image.
     public let sourceURL: URL
+    /// When using ``WebImageSelectionOutputMode/temporaryFileURL``, the path to a file in the system temporary directory. Copy or move it soon; the file may be removed by the system.
+    public let temporaryFileURL: URL?
 
     /// Creates a selection value (primarily for tests and advanced integration).
-    public init(data: Data, contentType: String?, sourceURL: URL) {
+    public init(data: Data, contentType: String?, sourceURL: URL, temporaryFileURL: URL? = nil) {
         self.data = data
         self.contentType = contentType
         self.sourceURL = sourceURL
+        self.temporaryFileURL = temporaryFileURL
     }
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelectionOutputMode.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImageSelectionOutputMode.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// How ``WebImagePicker`` builds ``WebImageSelection`` values passed to `onPick` after a download completes.
+public enum WebImageSelectionOutputMode: Sendable, Hashable {
+    /// Raw bytes in ``WebImageSelection/data`` (default). Same behavior as before this option existed.
+    case dataOnly
+    /// Ensures the payload decodes as a platform bitmap before completing; ``WebImageSelection/data`` still contains the bytes. Fails with ``WebImagePickerError/imageDecodeFailed`` if decoding is not possible.
+    case platformImage
+    /// Writes the payload to a unique file under the system temporary directory and sets ``WebImageSelection/temporaryFileURL``; ``WebImageSelection/data`` is empty to reduce memory use. The host should **copy or move** the file promptly and must not rely on it persisting; the system may delete temporary files at any time.
+    case temporaryFileURL
+}

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/InjectableURLSessionTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/InjectableURLSessionTests.swift
@@ -125,4 +125,57 @@ final class InjectableURLSessionTests: XCTestCase {
             XCTAssertEqual(error, .unsupportedImageType)
         }
     }
+
+    func testTemporaryFileOutputModeWritesPayloadAndClearsData() async throws {
+        let imageURL = URL(string: "https://example.com/photo.jpg")!
+        let payload = Data([0xFF, 0xD8, 0xFF, 0xD9])
+        StubURLProtocol.setHandler { request in
+            XCTAssertEqual(request.url, imageURL)
+            let response = HTTPURLResponse(
+                url: imageURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/jpeg"]
+            )!
+            return (response, payload)
+        }
+
+        var config = WebImagePickerConfiguration(allowedURLSchemes: ["https"])
+        config.selectionOutputMode = .temporaryFileURL
+        config.urlSession = urlSessionWithStub()
+
+        let selection = try await ImageDownloadService.download(from: imageURL, configuration: config)
+        let temp = try XCTUnwrap(selection.temporaryFileURL)
+        XCTAssertTrue(selection.data.isEmpty)
+        XCTAssertEqual(selection.sourceURL, imageURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: temp.path))
+        XCTAssertEqual(try Data(contentsOf: temp), payload)
+        try? FileManager.default.removeItem(at: temp)
+    }
+
+    func testPlatformImageOutputModeRejectsUndecodablePayload() async throws {
+        let imageURL = URL(string: "https://example.com/bad.jpg")!
+        let payload = Data([0x00, 0x01, 0x02])
+        StubURLProtocol.setHandler { request in
+            XCTAssertEqual(request.url, imageURL)
+            let response = HTTPURLResponse(
+                url: imageURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/jpeg"]
+            )!
+            return (response, payload)
+        }
+
+        var config = WebImagePickerConfiguration(allowedURLSchemes: ["https"])
+        config.selectionOutputMode = .platformImage
+        config.urlSession = urlSessionWithStub()
+
+        do {
+            _ = try await ImageDownloadService.download(from: imageURL, configuration: config)
+            XCTFail("expected imageDecodeFailed")
+        } catch let error as WebImagePickerError {
+            XCTAssertEqual(error, .imageDecodeFailed)
+        }
+    }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -115,6 +115,16 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         XCTAssertNotEqual(a, b)
     }
 
+    func testDefaultSelectionOutputModeIsDataOnly() {
+        XCTAssertEqual(WebImagePickerConfiguration.default.selectionOutputMode, .dataOnly)
+    }
+
+    func testSelectionOutputModeAffectsEquality() {
+        let a = WebImagePickerConfiguration(selectionOutputMode: .dataOnly)
+        let b = WebImagePickerConfiguration(selectionOutputMode: .temporaryFileURL)
+        XCTAssertNotEqual(a, b)
+    }
+
     func testDefaultDiscoveredImageSortIsDiscoveryOrder() {
         XCTAssertEqual(WebImagePickerConfiguration.default.discoveredImageSort, .discoveryOrder)
     }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerViewModelUserMessageTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerViewModelUserMessageTests.swift
@@ -14,6 +14,7 @@ final class WebImagePickerViewModelUserMessageTests: XCTestCase {
             .imageTooLarge,
             .downloadFailed,
             .unsupportedImageType,
+            .imageDecodeFailed,
         ]
         var seen = Set<String>()
         for err in cases {


### PR DESCRIPTION
## Summary
- Add `WebImageSelectionOutputMode` (`dataOnly`, `platformImage`, `temporaryFileURL`) and `WebImagePickerConfiguration.selectionOutputMode` (default `dataOnly` for backward compatibility).
- Extend `WebImageSelection` with optional `temporaryFileURL`; `makeUIImage()` / `makeNSImage()` read from that file when `data` is empty.
- `platformImage`: validates decode via UIKit/AppKit before completing; throws `WebImagePickerError.imageDecodeFailed` with localized copy (en/es).
- `temporaryFileURL`: writes bytes to a unique temp file and returns empty `data`; documented lifecycle.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: 98 tests passed; `swift build` clean

Closes #42

Made with [Cursor](https://cursor.com)