### PR TITLE
Fix #43: default selectionLimit 1 for single-tap pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- **Default `selectionLimit`** is now **`1`** (single-tap pick). Multi-select requires setting `selectionLimit` to a value greater than `1`. ([#43](https://github.com/fennelouski/SwiftUI-Web-Image-Picker/issues/43))
+
 ### Fixed
 
 ### Removed

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/GettingStarted.md
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.docc/GettingStarted.md
@@ -27,7 +27,7 @@ struct ContentView: View {
 
 ## Configure limits and extraction
 
-Build a ``WebImagePickerConfiguration`` to cap selection count, tune network limits, restrict URL schemes, and choose ``WebImageExtractionMode`` (static HTML vs. WebView). Pass it into ``View/webImagePicker(isPresented:configuration:onPick:)`` or ``WebImagePicker/init(configuration:onCancel:onPick:)``.
+Build a ``WebImagePickerConfiguration`` to tune selection count (default **1** for single-tap pick; raise the limit for multi-select), network limits, URL schemes, and ``WebImageExtractionMode`` (static HTML vs. WebView). Pass it into ``View/webImagePicker(isPresented:configuration:onPick:)`` or ``WebImagePicker/init(configuration:onCancel:onPick:)``.
 
 ## Use the selection
 

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -15,7 +15,7 @@ public enum WebImageExtractionMode: Sendable, Hashable {
 
 /// Tunable behavior for ``WebImagePicker`` and ``View/webImagePicker(isPresented:configuration:onPick:)``.
 ///
-/// Use ``default`` for HTTPS-only pages, multi-select up to 10, static HTML extraction, and shared `URLSession`.
+/// Use ``default`` for HTTPS-only pages, single-tap selection (``selectionLimit`` `1`), static HTML extraction, and shared `URLSession`. Set a higher ``selectionLimit`` for multi-select.
 public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// Maximum number of images the user may select. Use `1` for single selection.
     public var selectionLimit: Int
@@ -99,7 +99,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - selectionOutputMode: How ``WebImageSelection`` values are filled after download.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
-        selectionLimit: Int = 10,
+        selectionLimit: Int = 1,
         maximumConcurrentImageLoads: Int = 4,
         requestTimeout: TimeInterval = 30,
         allowedURLSchemes: Set<String> = ["https"],

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class WebImagePickerConfigurationTests: XCTestCase {
     func testDefaultSelectionLimit() {
-        XCTAssertEqual(WebImagePickerConfiguration.default.selectionLimit, 10)
+        XCTAssertEqual(WebImagePickerConfiguration.default.selectionLimit, 1)
     }
 
     func testDefaultAllowedSchemesHTTPSOnly() {

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ let nsImage = selection.makeNSImage()
 
 ### Configuration
 
+The default **`selectionLimit`** is **`1`**: one tap downloads and completes the pick (no separate Done step). Set **`selectionLimit`** to a value greater than `1` for multi-select with a Done button.
+
 ```swift
 var config = WebImagePickerConfiguration(
-    selectionLimit: 5,
     maximumConcurrentImageLoads: 4,
     requestTimeout: 30,
     allowedURLSchemes: ["https"],
@@ -131,7 +132,7 @@ var config = WebImagePickerConfiguration(
 }
 ```
 
-With **`selectionLimit == 1`**, tapping an image downloads it immediately and completes the pick (no separate Done step).
+For example, **`selectionLimit: 10`** allows up to ten images before the user taps Done.
 
 **`maximumDiscoveredImagesPerPage`** — Optional cap on how many image candidates are kept from **each** loaded page after discovery (default `nil` = unlimited). Truncation keeps the first N URLs in extractor order. For **`.staticHTML`**, that order is: `<img>` / `srcset` and `<picture>` sources in DOM order, then Open Graph and Twitter image tags, then `url(...)` values from inline `style` attributes and `<style>` blocks. In **multi-URL** mode (primary field + `additionalPageURLs` + extra rows), the limit applies **per page** before results are merged and de-duplicated across pages.
 

--- a/SwiftUI Web Image Picker/ContentView.swift
+++ b/SwiftUI Web Image Picker/ContentView.swift
@@ -13,7 +13,7 @@ import WebImagePicker
 struct ContentView: View {
     @State private var showPicker = false
     @State private var selections: [WebImageSelection] = []
-    @State private var pickerConfiguration = WebImagePickerConfiguration(selectionLimit: 5)
+    @State private var pickerConfiguration = WebImagePickerConfiguration()
 
     /// Static HTML–heavy pages that work well with default `.staticHTML` extraction.
     private enum SamplePage: String, CaseIterable {
@@ -72,10 +72,7 @@ struct ContentView: View {
     }
 
     private func presentPicker(initialURL: String?) {
-        pickerConfiguration = WebImagePickerConfiguration(
-            selectionLimit: 5,
-            initialURLString: initialURL
-        )
+        pickerConfiguration = WebImagePickerConfiguration(initialURLString: initialURL)
         showPicker = true
     }
 


### PR DESCRIPTION
## Summary
- Set `WebImagePickerConfiguration` initializer default `selectionLimit` from `10` to `1`; refresh package doc comment and DocC Getting Started.
- README configuration example uses defaults and explains multi-select as an explicit higher limit; demo app uses default configuration.
- CHANGELOG `[Unreleased]` notes the behavior change.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: 98 tests passed

Closes #43

Made with [Cursor](https://cursor.com)