### PR TITLE
Fix #44: optional Vision face-count sort for discoveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- `DiscoveredImageSort.faceCountDescending` / `faceCountAscending`: optional ranking by on-device face count (Vision `VNDetectFaceRectanglesRequest`), with `WebImagePickerConfiguration.maximumFaceCountAnalysisImages` to cap work per page. ([#44](https://github.com/fennelouski/SwiftUI-Web-Image-Picker/issues/44))
+
 ### Changed
 
 - **Default `selectionLimit`** is now **`1`** (single-tap pick). Multi-select requires setting `selectionLimit` to a value greater than `1`. ([#43](https://github.com/fennelouski/SwiftUI-Web-Image-Picker/issues/43))

--- a/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/AggregatedPageImageDiscovery.swift
@@ -21,7 +21,22 @@ enum AggregatedPageImageDiscovery {
         for pageURL in pageURLs {
             do {
                 var items = try await extractor.discoverImages(from: pageURL, configuration: configuration)
-                items = configuration.discoveredImageSort.orderedImages(items)
+                switch configuration.discoveredImageSort {
+                case .faceCountDescending:
+                    items = await DiscoveredImageFaceCountSorting.orderedImages(
+                        items,
+                        descending: true,
+                        configuration: configuration
+                    )
+                case .faceCountAscending:
+                    items = await DiscoveredImageFaceCountSorting.orderedImages(
+                        items,
+                        descending: false,
+                        configuration: configuration
+                    )
+                default:
+                    items = configuration.discoveredImageSort.orderedImages(items)
+                }
                 items = items.filter { ImageTypeAllowlist.passesDiscovery(url: $0.sourceURL, configuration: configuration) }
                 items = await DiscoveredImageDimensionFiltering.filtered(images: items, configuration: configuration)
                 if let cap = configuration.maximumDiscoveredImagesPerPage {

--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageFaceCountSorting.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageFaceCountSorting.swift
@@ -1,0 +1,127 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Vision
+
+/// Ranks discovered images by on-device face detection (``VNDetectFaceRectanglesRequest``). Uses a small ranged GET per URL (same cap as dimension probing). Results are cached only for the duration of one ``orderedImages`` call.
+enum DiscoveredImageFaceCountSorting {
+    private static let probeByteLimit = 65_536
+
+    static func orderedImages(
+        _ images: [DiscoveredImage],
+        descending: Bool,
+        configuration: WebImagePickerConfiguration
+    ) async -> [DiscoveredImage] {
+        guard !images.isEmpty else { return images }
+        let maxAnalyze = configuration.maximumFaceCountAnalysisImages
+        guard maxAnalyze > 0 else { return images }
+
+        let headCount = min(maxAnalyze, images.count)
+        let head = Array(images[..<headCount])
+        let tail = Array(images.dropFirst(headCount))
+
+        let concurrency = max(1, configuration.maximumConcurrentImageLoads)
+        var counts: [URL: Int] = [:]
+        counts.reserveCapacity(head.count)
+
+        var start = head.startIndex
+        while start < head.endIndex {
+            let end = head.index(start, offsetBy: concurrency, limitedBy: head.endIndex) ?? head.endIndex
+            let chunk = Array(head[start..<end])
+
+            let indexed: [(Int, URL, Int)] = await withTaskGroup(
+                of: (Int, URL, Int).self,
+                returning: [(Int, URL, Int)].self
+            ) { group in
+                for (offset, item) in chunk.enumerated() {
+                    let url = item.sourceURL
+                    group.addTask {
+                        let data = await Self.fetchProbeData(for: url, configuration: configuration)
+                        let n = data.map { Self.faceCount(from: $0) } ?? 0
+                        return (offset, url, n)
+                    }
+                }
+                var acc: [(Int, URL, Int)] = []
+                for await row in group {
+                    acc.append(row)
+                }
+                return acc.sorted { $0.0 < $1.0 }
+            }
+
+            for (_, url, n) in indexed {
+                counts[url] = n
+            }
+
+            start = end
+        }
+
+        let sortedHead = sortStableByFaceCount(head, counts: counts, descending: descending)
+        return sortedHead + tail
+    }
+
+    /// Stable sort by face count; ties keep discovery order (`counts` default is `0` per URL).
+    internal static func sortStableByFaceCount(
+        _ images: [DiscoveredImage],
+        counts: [URL: Int],
+        descending: Bool
+    ) -> [DiscoveredImage] {
+        images.enumerated().sorted { lhs, rhs in
+            let lc = counts[lhs.element.sourceURL, default: 0]
+            let rc = counts[rhs.element.sourceURL, default: 0]
+            if descending {
+                if lc != rc { return lc > rc }
+            } else {
+                if lc != rc { return lc < rc }
+            }
+            return lhs.offset < rhs.offset
+        }.map(\.element)
+    }
+
+    private static func faceCount(from data: Data) -> Int {
+        guard let cgImage = cgImage(from: data) else { return 0 }
+        let request = VNDetectFaceRectanglesRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage, orientation: .up, options: [:])
+        do {
+            try handler.perform([request])
+            return request.results?.count ?? 0
+        } catch {
+            return 0
+        }
+    }
+
+    private static func cgImage(from data: Data) -> CGImage? {
+        guard let src = CGImageSourceCreateWithData(data as CFData, [kCGImageSourceShouldCache: false] as CFDictionary),
+              CGImageSourceGetCount(src) > 0 else { return nil }
+
+        let thumbOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: 640,
+        ]
+        if let thumb = CGImageSourceCreateThumbnailAtIndex(src, 0, thumbOptions as CFDictionary) {
+            return thumb
+        }
+        return CGImageSourceCreateImageAtIndex(src, 0, nil)
+    }
+
+    private static func fetchProbeData(for url: URL, configuration: WebImagePickerConfiguration) async -> Data? {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = configuration.requestTimeout
+        if let ua = configuration.userAgent {
+            request.setValue(ua, forHTTPHeaderField: "User-Agent")
+        }
+
+        let cap = max(1024, configuration.maximumImageDownloadBytes)
+        let byteLimit = min(probeByteLimit, cap)
+        request.setValue("bytes=0-\(byteLimit - 1)", forHTTPHeaderField: "Range")
+
+        do {
+            let (data, response) = try await configuration.urlSession.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
+                return nil
+            }
+            return Data(data.prefix(byteLimit))
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageSort.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageSort.swift
@@ -16,9 +16,17 @@ public enum DiscoveredImageSort: Sendable, Hashable {
     /// Portrait-like URLs first, then unknown or square, then landscape, using `w`/`width` and `h`/`height` query integers when both exist. URLs missing either dimension go in the middle bucket (same as square).
     case aspectRatioBucketPortraitFirst
 
+    /// More faces first (on-device Vision). See ``WebImagePickerConfiguration/maximumFaceCountAnalysisImages``. **Privacy:** analysis runs locally; uses network and CPU/battery proportional to how many images are analyzed.
+    case faceCountDescending
+
+    /// Fewer faces first (on-device Vision). Same performance and privacy notes as ``faceCountDescending``.
+    case faceCountAscending
+
     func orderedImages(_ images: [DiscoveredImage]) -> [DiscoveredImage] {
         switch self {
         case .discoveryOrder:
+            return images
+        case .faceCountDescending, .faceCountAscending:
             return images
         case .sourceURLAscending:
             return images.enumerated().sorted { lhs, rhs in

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -74,6 +74,9 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// How completed downloads are exposed in ``WebImageSelection`` (default ``WebImageSelectionOutputMode/dataOnly``).
     public var selectionOutputMode: WebImageSelectionOutputMode
 
+    /// When using ``DiscoveredImageSort/faceCountDescending`` or ``faceCountAscending``, the maximum number of images **per page** (in discovery order) to probe and analyze with on-device Vision. Additional images keep discovery order after the sorted prefix. Use `0` to skip analysis (no face-based reordering). Default `40`.
+    public var maximumFaceCountAnalysisImages: Int
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -97,6 +100,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - allowedImageTypeIdentifiers: Optional `UTType` identifier allowlist; `nil` or empty disables type filtering.
     ///   - unknownImageTypePolicy: Behavior for unknown types when an allowlist is active.
     ///   - selectionOutputMode: How ``WebImageSelection`` values are filled after download.
+    ///   - maximumFaceCountAnalysisImages: Vision face-sort budget per page; `0` disables analysis.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 1,
@@ -117,6 +121,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         allowedImageTypeIdentifiers: Set<String>? = nil,
         unknownImageTypePolicy: WebImageUnknownTypePolicy = .allow,
         selectionOutputMode: WebImageSelectionOutputMode = .dataOnly,
+        maximumFaceCountAnalysisImages: Int = 40,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -137,6 +142,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.allowedImageTypeIdentifiers = allowedImageTypeIdentifiers.flatMap { $0.isEmpty ? nil : $0 }
         self.unknownImageTypePolicy = unknownImageTypePolicy
         self.selectionOutputMode = selectionOutputMode
+        self.maximumFaceCountAnalysisImages = max(0, maximumFaceCountAnalysisImages)
         self.urlSession = urlSession
     }
 
@@ -161,6 +167,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.allowedImageTypeIdentifiers == rhs.allowedImageTypeIdentifiers
             && lhs.unknownImageTypePolicy == rhs.unknownImageTypePolicy
             && lhs.selectionOutputMode == rhs.selectionOutputMode
+            && lhs.maximumFaceCountAnalysisImages == rhs.maximumFaceCountAnalysisImages
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -182,6 +189,7 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(allowedImageTypeIdentifiers)
         hasher.combine(unknownImageTypePolicy)
         hasher.combine(selectionOutputMode)
+        hasher.combine(maximumFaceCountAnalysisImages)
     }
 
     private static func hashCGSizeOptional(_ size: CGSize?, into hasher: inout Hasher) {

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/AggregatedPageImageDiscoveryTests.swift
@@ -221,6 +221,34 @@ final class AggregatedPageImageDiscoveryTests: XCTestCase {
         XCTAssertEqual(merge.images.map(\.sourceURL), [portrait, square])
     }
 
+    func testFaceCountSortSkippedWhenAnalysisBudgetZero() async throws {
+        let page = URL(string: "https://one.example/")!
+        let u1 = URL(string: "https://cdn.example/1.jpg")!
+        let u2 = URL(string: "https://cdn.example/2.jpg")!
+        let u3 = URL(string: "https://cdn.example/3.jpg")!
+
+        let extractor = MockPageImageExtractor(pageResults: [
+            page: .success([
+                DiscoveredImage(sourceURL: u1, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: u2, accessibilityLabel: nil),
+                DiscoveredImage(sourceURL: u3, accessibilityLabel: nil),
+            ]),
+        ])
+
+        var config = WebImagePickerConfiguration.default
+        config.discoveredImageSort = .faceCountDescending
+        config.maximumFaceCountAnalysisImages = 0
+
+        let merge = await AggregatedPageImageDiscovery.discoverImages(
+            pageURLs: [page],
+            configuration: config,
+            extractor: extractor
+        )
+
+        XCTAssertTrue(merge.failedPageURLs.isEmpty)
+        XCTAssertEqual(merge.images.map(\.sourceURL), [u1, u2, u3])
+    }
+
     func testAllowlistedImageTypesFilterDiscoveredURLs() async throws {
         let page = URL(string: "https://one.example/")!
         let jpg = URL(string: "https://cdn.example/a.jpg")!

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageFaceCountSortingTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageFaceCountSortingTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WebImagePicker
+
+final class DiscoveredImageFaceCountSortingTests: XCTestCase {
+    func testSortStableByFaceCountDescending() {
+        let u1 = URL(string: "https://cdn.example/1.jpg")!
+        let u2 = URL(string: "https://cdn.example/2.jpg")!
+        let u3 = URL(string: "https://cdn.example/3.jpg")!
+        let images = [
+            DiscoveredImage(sourceURL: u1, accessibilityLabel: nil),
+            DiscoveredImage(sourceURL: u2, accessibilityLabel: nil),
+            DiscoveredImage(sourceURL: u3, accessibilityLabel: nil),
+        ]
+        let counts = [u1: 1, u2: 3, u3: 2]
+        let out = DiscoveredImageFaceCountSorting.sortStableByFaceCount(images, counts: counts, descending: true)
+        XCTAssertEqual(out.map(\.sourceURL), [u2, u3, u1])
+    }
+
+    func testSortStableByFaceCountAscendingTieBreaker() {
+        let u1 = URL(string: "https://cdn.example/a.jpg")!
+        let u2 = URL(string: "https://cdn.example/b.jpg")!
+        let u3 = URL(string: "https://cdn.example/c.jpg")!
+        let images = [
+            DiscoveredImage(sourceURL: u1, accessibilityLabel: nil),
+            DiscoveredImage(sourceURL: u2, accessibilityLabel: nil),
+            DiscoveredImage(sourceURL: u3, accessibilityLabel: nil),
+        ]
+        let counts = [u1: 2, u2: 2, u3: 1]
+        let out = DiscoveredImageFaceCountSorting.sortStableByFaceCount(images, counts: counts, descending: false)
+        XCTAssertEqual(out.map(\.sourceURL), [u3, u1, u2])
+    }
+}

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -135,6 +135,26 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         XCTAssertNotEqual(a, b)
     }
 
+    func testFaceCountSortModesAffectEquality() {
+        let a = WebImagePickerConfiguration(discoveredImageSort: .faceCountDescending)
+        let b = WebImagePickerConfiguration(discoveredImageSort: .faceCountAscending)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testDefaultMaximumFaceCountAnalysisImages() {
+        XCTAssertEqual(WebImagePickerConfiguration.default.maximumFaceCountAnalysisImages, 40)
+    }
+
+    func testMaximumFaceCountAnalysisImagesClampedNonNegative() {
+        XCTAssertEqual(WebImagePickerConfiguration(maximumFaceCountAnalysisImages: -5).maximumFaceCountAnalysisImages, 0)
+    }
+
+    func testMaximumFaceCountAnalysisImagesAffectsEquality() {
+        let a = WebImagePickerConfiguration(maximumFaceCountAnalysisImages: 10)
+        let b = WebImagePickerConfiguration(maximumFaceCountAnalysisImages: 20)
+        XCTAssertNotEqual(a, b)
+    }
+
     func testSimilarImageDeduplicationAffectsEquality() {
         let a = WebImagePickerConfiguration(similarImageDeduplication: .disabled)
         let b = WebImagePickerConfiguration(similarImageDeduplication: .normalizedResourceURL)


### PR DESCRIPTION
## Summary
- Add `DiscoveredImageSort.faceCountDescending` / `faceCountAscending` using on-device `VNDetectFaceRectanglesRequest` on a downscaled `CGImage` from a ranged GET (same 64KB-style cap as dimension probing).
- Add `WebImagePickerConfiguration.maximumFaceCountAnalysisImages` (default `40`, `0` skips Vision and preserves discovery order). Remaining images per page stay in discovery order after the analyzed prefix.
- Stable tie-break on original index; results only cached for one ordering pass. CHANGELOG entry under Unreleased.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- Result: 105 tests passed

Closes #44

Made with [Cursor](https://cursor.com)