### PR TITLE
Fix #45: text search over image metadata (alt, title, URL)

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImage.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImage.swift
@@ -6,9 +6,12 @@ public struct DiscoveredImage: Identifiable, Hashable, Sendable {
 
     public let sourceURL: URL
     public let accessibilityLabel: String?
+    /// HTML `title` attribute when present (typically from `<img title="…">`).
+    public let title: String?
 
-    public init(sourceURL: URL, accessibilityLabel: String?) {
+    public init(sourceURL: URL, accessibilityLabel: String?, title: String? = nil) {
         self.sourceURL = sourceURL
         self.accessibilityLabel = accessibilityLabel
+        self.title = title
     }
 }

--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageMetadataSearch.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageMetadataSearch.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Case-insensitive substring filtering of ``DiscoveredImage`` for the browsing grid search field.
+enum DiscoveredImageMetadataSearch {
+    static func normalizedQuery(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    /// Returns `true` when the trimmed query is empty or when the image matches alt, title, URL path, or full URL string (case-insensitive).
+    static func matches(_ image: DiscoveredImage, rawQuery: String) -> Bool {
+        let q = normalizedQuery(rawQuery)
+        guard !q.isEmpty else { return true }
+        if let alt = image.accessibilityLabel, alt.lowercased().contains(q) {
+            return true
+        }
+        if let title = image.title, title.lowercased().contains(q) {
+            return true
+        }
+        if image.sourceURL.path.lowercased().contains(q) {
+            return true
+        }
+        if image.sourceURL.absoluteString.lowercased().contains(q) {
+            return true
+        }
+        return false
+    }
+
+    static func filteredDiscoveries(_ images: [DiscoveredImage], rawQuery: String) -> [DiscoveredImage] {
+        let q = normalizedQuery(rawQuery)
+        guard !q.isEmpty else { return images }
+        return images.filter { matches($0, rawQuery: q) }
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/Resources/en.lproj/Localizable.strings
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,6 @@
 "webimage.a11y.imageFromWeb" = "Image from web";
+"webimage.a11y.imageSearchField" = "Search images";
+"webimage.a11y.imageSearchFieldHint" = "Filters the list by alt text, title, or image address.";
 "webimage.cancel" = "Cancel";
 "webimage.changeURL" = "Change URL";
 "webimage.done" = "Done";
@@ -27,3 +29,4 @@
 "webimage.extraPagePlaceholder" = "https://another.example.com";
 "webimage.error.allPagesFailed" = "Could not load images from any of the pages.";
 "webimage.partialPageFailuresFormat" = "%lld page(s) could not be loaded. Images from the other pages are shown.";
+"webimage.searchPlaceholder" = "Search by alt, title, or URL";

--- a/Packages/WebImagePicker/Sources/WebImagePicker/Resources/es.lproj/Localizable.strings
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/Resources/es.lproj/Localizable.strings
@@ -1,4 +1,6 @@
 "webimage.a11y.imageFromWeb" = "Imagen de la web";
+"webimage.a11y.imageSearchField" = "Buscar imágenes";
+"webimage.a11y.imageSearchFieldHint" = "Filtra la lista por texto alternativo, título o dirección de la imagen.";
 "webimage.cancel" = "Cancelar";
 "webimage.changeURL" = "Cambiar URL";
 "webimage.done" = "Listo";
@@ -27,3 +29,4 @@
 "webimage.extraPagePlaceholder" = "https://otro.ejemplo.com";
 "webimage.error.allPagesFailed" = "No se pudieron cargar imágenes de ninguna de las páginas.";
 "webimage.partialPageFailuresFormat" = "No se pudieron cargar %lld página(s). Se muestran imágenes de las demás.";
+"webimage.searchPlaceholder" = "Buscar por texto alt, título o URL";

--- a/Packages/WebImagePicker/Sources/WebImagePicker/StaticHTMLExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/StaticHTMLExtractor.swift
@@ -50,7 +50,7 @@ public struct StaticHTMLExtractor: PageImageExtractor {
             return resolved
         }
 
-        func append(raw: String?, alt: String?) {
+        func append(raw: String?, alt: String?, title: String?) {
             guard let raw else { return }
             guard let url = normalizedURL(from: raw) else { return }
             let key = DiscoveredImageDeduplicationKey.string(
@@ -60,18 +60,20 @@ public struct StaticHTMLExtractor: PageImageExtractor {
             guard !seen.contains(key) else { return }
             seen.insert(key)
             let label = alt.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.flatMap { $0.isEmpty ? nil : $0 }
-            images.append(DiscoveredImage(sourceURL: url, accessibilityLabel: label))
+            let titleLabel = title.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.flatMap { $0.isEmpty ? nil : $0 }
+            images.append(DiscoveredImage(sourceURL: url, accessibilityLabel: label, title: titleLabel))
         }
 
         let imgs = try doc.select("img[src], img[srcset]")
         for element in imgs.array() {
             let alt = try? element.attr("alt")
+            let imgTitle = try? element.attr("title")
             if let srcset = try? element.attr("srcset"), !srcset.isEmpty,
                let picked = SrcSetParser.bestURL(from: srcset, baseURL: pageURL)
             {
-                append(raw: picked.absoluteString, alt: alt)
+                append(raw: picked.absoluteString, alt: alt, title: imgTitle)
             } else if let src = try? element.attr("src") {
-                append(raw: src, alt: alt)
+                append(raw: src, alt: alt, title: imgTitle)
             }
         }
 
@@ -80,21 +82,21 @@ public struct StaticHTMLExtractor: PageImageExtractor {
             if let srcset = try? element.attr("srcset"), !srcset.isEmpty,
                let picked = SrcSetParser.bestURL(from: srcset, baseURL: pageURL)
             {
-                append(raw: picked.absoluteString, alt: nil)
+                append(raw: picked.absoluteString, alt: nil, title: nil)
             }
         }
 
         let ogImages = try doc.select("meta[property=og:image]")
         for element in ogImages.array() {
             if let content = try? element.attr("content") {
-                append(raw: content, alt: nil)
+                append(raw: content, alt: nil, title: nil)
             }
         }
 
         let twitterImages = try doc.select("meta[name=twitter:image], meta[name=twitter:image:src]")
         for element in twitterImages.array() {
             if let content = try? element.attr("content") {
-                append(raw: content, alt: nil)
+                append(raw: content, alt: nil, title: nil)
             }
         }
 
@@ -102,7 +104,7 @@ public struct StaticHTMLExtractor: PageImageExtractor {
         for element in inlineStyled.array() {
             if let style = try? element.attr("style"), !style.isEmpty {
                 for raw in CSSImageURLExtractor.urlArguments(from: style) {
-                    append(raw: raw, alt: nil)
+                    append(raw: raw, alt: nil, title: nil)
                 }
             }
         }
@@ -112,7 +114,7 @@ public struct StaticHTMLExtractor: PageImageExtractor {
             let css = (try? element.html()) ?? ""
             if css.isEmpty { continue }
             for raw in CSSImageURLExtractor.urlArgumentsFromBackgroundDeclarations(in: css) {
-                append(raw: raw, alt: nil)
+                append(raw: raw, alt: nil, title: nil)
             }
         }
 

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePicker.swift
@@ -172,8 +172,28 @@ public struct WebImagePicker: View {
     }
 
     private var browsingView: some View {
-        ScrollView {
+        @Bindable var model = model
+        return ScrollView {
             VStack(alignment: .leading, spacing: 8) {
+                TextField(
+                    String(localized: String.LocalizationValue("webimage.searchPlaceholder"), bundle: WebImagePickerBundle.module),
+                    text: $model.imageMetadataSearchQuery
+                )
+#if os(iOS) || os(tvOS) || os(visionOS)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+#endif
+#if os(macOS)
+                .textFieldStyle(.roundedBorder)
+#endif
+                .accessibilityLabel(
+                    String(localized: String.LocalizationValue("webimage.a11y.imageSearchField"), bundle: WebImagePickerBundle.module)
+                )
+                .accessibilityHint(
+                    String(localized: String.LocalizationValue("webimage.a11y.imageSearchFieldHint"), bundle: WebImagePickerBundle.module)
+                )
+                .accessibilityIdentifier("webimage.imageMetadataSearch")
+
                 if let notice = model.aggregationNotice {
                     Text(notice)
                         .font(.subheadline)
@@ -193,7 +213,7 @@ public struct WebImagePicker: View {
                         .accessibilityIdentifier("webimage.browsingDownloadError")
                 }
                 MasonryLayout(columns: masonryColumnCount, spacing: 8) {
-                    ForEach(model.discovered) { item in
+                    ForEach(model.discoveredForDisplay) { item in
                         DiscoveredImageTile(
                             item: item,
                             selected: model.selectedURLs.contains(item.sourceURL),

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
@@ -18,6 +18,8 @@ final class WebImagePickerViewModel {
     var urlString: String = ""
     var extraPageRows: [WebImagePickerExtraPageRow] = []
     var discovered: [DiscoveredImage] = []
+    /// Filters the browsing grid by alt text, optional `title`, and URL (case-insensitive substring).
+    var imageMetadataSearchQuery: String = ""
     var selectedURLs: Set<URL> = []
     var phase: Phase = .urlEntry
     var errorMessage: String?
@@ -51,6 +53,11 @@ final class WebImagePickerViewModel {
         if let raw = configuration.initialURLString?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
             urlString = raw
         }
+    }
+
+    /// Images shown in the grid after applying ``imageMetadataSearchQuery``.
+    var discoveredForDisplay: [DiscoveredImage] {
+        DiscoveredImageMetadataSearch.filteredDiscoveries(discovered, rawQuery: imageMetadataSearchQuery)
     }
 
     var canStartLoad: Bool {
@@ -97,6 +104,7 @@ final class WebImagePickerViewModel {
         }
 
         discovered = merge.images
+        imageMetadataSearchQuery = ""
         selectedURLs = []
         phase = .browsing
         if !merge.failedPageURLs.isEmpty {
@@ -202,6 +210,7 @@ final class WebImagePickerViewModel {
     func beginChangingURL() {
         phase = .urlEntry
         discovered = []
+        imageMetadataSearchQuery = ""
         selectedURLs = []
         errorMessage = nil
         aggregationNotice = nil

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebViewPageImageExtractor.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebViewPageImageExtractor.swift
@@ -74,8 +74,11 @@ public struct WebViewPageImageExtractor: PageImageExtractor {
             let label = candidate.altText?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let cleanedLabel = label?.isEmpty == true ? nil : label
+            let titleRaw = candidate.title?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let cleanedTitle = titleRaw?.isEmpty == true ? nil : titleRaw
 
-            images.append(DiscoveredImage(sourceURL: url, accessibilityLabel: cleanedLabel))
+            images.append(DiscoveredImage(sourceURL: url, accessibilityLabel: cleanedLabel, title: cleanedTitle))
         }
 
         return images
@@ -91,6 +94,8 @@ internal struct WebViewRawCandidate: Equatable, Sendable {
     internal var value: String
     internal var altText: String?
     internal var kind: Kind
+    /// HTML `title` attribute when present (from `<img>` in the DOM collector).
+    internal var title: String?
 }
 
 #if canImport(WebKit)
@@ -145,25 +150,27 @@ private final class WebViewDOMLoader: NSObject {
         let script = #"""
         (() => {
           const out = [];
-          const push = (value, alt, kind) => {
+          const push = (value, alt, kind, title) => {
             if (typeof value !== 'string') return;
-            out.push({ value, altText: typeof alt === 'string' ? alt : null, kind });
+            const t = title != null && typeof title === 'string' ? title : null;
+            out.push({ value, altText: typeof alt === 'string' ? alt : null, kind, titleText: t });
           };
 
           document.querySelectorAll('img').forEach((img) => {
-            push(img.currentSrc || img.src || '', img.alt || null, 'url');
+            const titleAttr = img.getAttribute('title');
+            push(img.currentSrc || img.src || '', img.alt || null, 'url', titleAttr);
             const srcset = img.getAttribute('srcset');
-            if (srcset) push(srcset, img.alt || null, 'srcset');
+            if (srcset) push(srcset, img.alt || null, 'srcset', titleAttr);
           });
 
           document.querySelectorAll('picture source[srcset]').forEach((source) => {
             const srcset = source.getAttribute('srcset');
-            if (srcset) push(srcset, null, 'srcset');
+            if (srcset) push(srcset, null, 'srcset', null);
           });
 
           document.querySelectorAll('meta[property="og:image"],meta[name="twitter:image"],meta[name="twitter:image:src"]').forEach((meta) => {
             const content = meta.getAttribute('content');
-            if (content) push(content, null, 'url');
+            if (content) push(content, null, 'url', null);
           });
 
           return out;
@@ -189,7 +196,8 @@ private final class WebViewDOMLoader: NSObject {
             let kindString = item["kind"] as? String ?? WebViewRawCandidate.Kind.url.rawValue
             let kind = WebViewRawCandidate.Kind(rawValue: kindString) ?? .url
             let altText = item["altText"] as? String
-            return WebViewRawCandidate(value: value, altText: altText, kind: kind)
+            let titleText = item["titleText"] as? String
+            return WebViewRawCandidate(value: value, altText: altText, kind: kind, title: titleText)
         }
     }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageMetadataSearchTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageMetadataSearchTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import WebImagePicker
+
+final class DiscoveredImageMetadataSearchTests: XCTestCase {
+    private let base = URL(string: "https://example.com/photos/sunset.jpg")!
+
+    func testEmptyQueryReturnsAll() {
+        let images = [
+            DiscoveredImage(sourceURL: base, accessibilityLabel: "Sun", title: nil),
+            DiscoveredImage(sourceURL: URL(string: "https://other.test/a.png")!, accessibilityLabel: nil, title: nil),
+        ]
+        let out = DiscoveredImageMetadataSearch.filteredDiscoveries(images, rawQuery: "")
+        XCTAssertEqual(out.count, 2)
+        XCTAssertEqual(out.map(\.id), images.map(\.id))
+    }
+
+    func testWhitespaceOnlyQueryReturnsAll() {
+        let images = [DiscoveredImage(sourceURL: base, accessibilityLabel: "A", title: nil)]
+        let out = DiscoveredImageMetadataSearch.filteredDiscoveries(images, rawQuery: "  \t")
+        XCTAssertEqual(out.count, 1)
+    }
+
+    func testMatchesAltCaseInsensitive() {
+        let img = DiscoveredImage(sourceURL: base, accessibilityLabel: "Golden Hour", title: nil)
+        XCTAssertTrue(DiscoveredImageMetadataSearch.matches(img, rawQuery: "golden"))
+        XCTAssertFalse(DiscoveredImageMetadataSearch.matches(img, rawQuery: "moon"))
+    }
+
+    func testMatchesTitleCaseInsensitive() {
+        let img = DiscoveredImage(sourceURL: base, accessibilityLabel: nil, title: "Beach at dusk")
+        XCTAssertTrue(DiscoveredImageMetadataSearch.matches(img, rawQuery: "BEACH"))
+        XCTAssertFalse(DiscoveredImageMetadataSearch.matches(img, rawQuery: "mountain"))
+    }
+
+    func testMatchesURLPathAndFullString() {
+        let img = DiscoveredImage(sourceURL: base, accessibilityLabel: nil, title: nil)
+        XCTAssertTrue(DiscoveredImageMetadataSearch.matches(img, rawQuery: "photos"))
+        XCTAssertTrue(DiscoveredImageMetadataSearch.matches(img, rawQuery: "example.com"))
+    }
+
+    func testFilteredListExcludesNonMatching() {
+        let a = DiscoveredImage(sourceURL: URL(string: "https://x.com/one.png")!, accessibilityLabel: "cat", title: nil)
+        let b = DiscoveredImage(sourceURL: URL(string: "https://x.com/two.png")!, accessibilityLabel: "dog", title: nil)
+        let out = DiscoveredImageMetadataSearch.filteredDiscoveries([a, b], rawQuery: "cat")
+        XCTAssertEqual(out.map(\.sourceURL.absoluteString), [a.sourceURL.absoluteString])
+    }
+}

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/StaticHTMLExtractorTests.swift
@@ -13,6 +13,14 @@ final class StaticHTMLExtractorTests: XCTestCase {
         XCTAssertEqual(items[0].accessibilityLabel, "Logo")
     }
 
+    func testImgTitleAttributeIsCaptured() throws {
+        let html = #"<html><body><img src="/b.png" alt="A" title="Full title"></body></html>"#
+        let page = URL(string: "https://example.com/")!
+        let items = try StaticHTMLExtractor.discover(from: html, pageURL: page, configuration: defaultConfig)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].title, "Full title")
+    }
+
     func testSrcsetPicksLargestWidth() throws {
         let html = #"""
         <img src="/tiny.png" srcset="https://cdn.example.com/small.png 480w, https://cdn.example.com/big.png 800w" alt="">

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebViewPageImageExtractorTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebViewPageImageExtractorTests.swift
@@ -19,6 +19,39 @@ final class WebViewPageImageExtractorTests: XCTestCase {
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results[0].sourceURL.absoluteString, "https://example.com/img/hero.png")
         XCTAssertEqual(results[0].accessibilityLabel, "Hero")
+        XCTAssertNil(results[0].title)
+    }
+
+    func testNormalizePreservesImgTitleAttribute() {
+        let pageURL = URL(string: "https://example.com/")!
+        let candidates: [WebViewRawCandidate] = [
+            .init(value: "/pic.png", altText: nil, kind: .url, title: "Tooltip copy"),
+        ]
+
+        let results = WebViewPageImageExtractor.normalize(
+            rawCandidates: candidates,
+            pageURL: pageURL,
+            configuration: config
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].title, "Tooltip copy")
+    }
+
+    func testNormalizeTrimsWhitespaceTitle() {
+        let pageURL = URL(string: "https://example.com/")!
+        let candidates: [WebViewRawCandidate] = [
+            .init(value: "/pic.png", altText: nil, kind: .url, title: "  \n"),
+        ]
+
+        let results = WebViewPageImageExtractor.normalize(
+            rawCandidates: candidates,
+            pageURL: pageURL,
+            configuration: config
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertNil(results[0].title)
     }
 
     func testNormalizePicksLargestSrcSetCandidate() {


### PR DESCRIPTION
## Summary
- Add optional `title` on `DiscoveredImage` and capture `<img title>` in static HTML and WebView JS extraction.
- Case-insensitive substring search over alt, title, URL path, and full URL; browsing grid uses `discoveredForDisplay` while selection order still follows full `discovered`.
- Localized search field with accessibility label, hint, and identifier; EN/ES strings.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- All 114 tests passed.

Closes #45

Made with [Cursor](https://cursor.com)