### PR TITLE
Fix #47: Vision OCR index for in-image search

### DIFF
--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageMetadataSearch.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageMetadataSearch.swift
@@ -25,8 +25,12 @@ enum DiscoveredImageMetadataSearch {
         return (s, tokens)
     }
 
-    /// Returns `true` when the trimmed query is empty or when the image matches alt, title, URL path, or full URL string (case-insensitive).
-    static func matches(_ image: DiscoveredImage, rawQuery: String) -> Bool {
+    /// Returns `true` when the trimmed query is empty or when the image matches alt, title, URL path, full URL string, or optional Vision OCR text (case-insensitive).
+    static func matches(
+        _ image: DiscoveredImage,
+        rawQuery: String,
+        recognizedTextByURL: [URL: String]? = nil
+    ) -> Bool {
         let q = normalizedQuery(rawQuery)
         guard !q.isEmpty else { return true }
         if let alt = image.accessibilityLabel, alt.lowercased().contains(q) {
@@ -41,13 +45,17 @@ enum DiscoveredImageMetadataSearch {
         if image.sourceURL.absoluteString.lowercased().contains(q) {
             return true
         }
+        if let blob = recognizedTextByURL?[image.sourceURL], blob.lowercased().contains(q) {
+            return true
+        }
         return false
     }
 
     static func filteredDiscoveries(
         _ images: [DiscoveredImage],
         rawQuery: String,
-        configuration: WebImagePickerConfiguration = .default
+        configuration: WebImagePickerConfiguration = .default,
+        recognizedTextByURL: [URL: String]? = nil
     ) -> [DiscoveredImage] {
         let (textPart, formatTokens) = splitFormatTokens(from: rawQuery)
         let trimmedText = textPart.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -63,7 +71,7 @@ enum DiscoveredImageMetadataSearch {
             if hasFormats, !urlMatchesAnyFormatToken(image.sourceURL, tokens: formatTokens, configuration: configuration) {
                 return false
             }
-            if hasText, !matches(image, rawQuery: trimmedText) {
+            if hasText, !matches(image, rawQuery: trimmedText, recognizedTextByURL: recognizedTextByURL) {
                 return false
             }
             return true

--- a/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageTextRecognition.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/DiscoveredImageTextRecognition.swift
@@ -1,0 +1,105 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Vision
+
+/// On-device text recognition for in-image search (``VNRecognizeTextRequest``), using the same ranged GET probe pattern as dimension / face analysis.
+enum DiscoveredImageTextRecognition {
+    private static let probeByteLimit = 384_000
+
+    /// Builds a map of normalized image URL → concatenated recognized strings for the first chunk of URLs, respecting cancellation between batches.
+    static func buildIndex(urls: [URL], configuration: WebImagePickerConfiguration) async -> [URL: String] {
+        guard !urls.isEmpty else { return [:] }
+        let concurrency = max(1, configuration.maximumConcurrentImageTextRecognition)
+        var combined: [URL: String] = [:]
+        combined.reserveCapacity(urls.count)
+
+        var start = urls.startIndex
+        while start < urls.endIndex {
+            try? Task.checkCancellation()
+            let end = urls.index(start, offsetBy: concurrency, limitedBy: urls.endIndex) ?? urls.endIndex
+            let chunk = Array(urls[start..<end])
+
+            let rows: [(URL, String)] = await withTaskGroup(of: (URL, String).self, returning: [(URL, String)].self) { group in
+                for url in chunk {
+                    group.addTask {
+                        let data = await Self.fetchProbeData(for: url, configuration: configuration)
+                        let text = data.flatMap {
+                            Self.recognizedText(fromImageData: $0, languages: configuration.imageTextRecognitionLanguages)
+                        } ?? ""
+                        return (url, text)
+                    }
+                }
+                var acc: [(URL, String)] = []
+                for await row in group {
+                    acc.append(row)
+                }
+                return acc
+            }
+
+            for (url, text) in rows where !text.isEmpty {
+                combined[url] = text
+            }
+
+            start = end
+        }
+
+        return combined
+    }
+
+    /// Test hook: run Vision OCR on decoded image bytes.
+    internal static func recognizedText(fromImageData data: Data, languages: [String]?) -> String? {
+        guard let cgImage = cgImageForRecognition(from: data) else { return nil }
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        if let languages, !languages.isEmpty {
+            request.recognitionLanguages = languages
+        }
+        let handler = VNImageRequestHandler(cgImage: cgImage, orientation: .up, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            return nil
+        }
+        guard let observations = request.results else { return nil }
+        let parts = observations.compactMap { $0.topCandidates(1).first?.string }
+        let joined = parts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        return joined.isEmpty ? nil : joined
+    }
+
+    private static func cgImageForRecognition(from data: Data) -> CGImage? {
+        guard let src = CGImageSourceCreateWithData(data as CFData, [kCGImageSourceShouldCache: false] as CFDictionary),
+              CGImageSourceGetCount(src) > 0 else { return nil }
+
+        let thumbOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: 1280,
+        ]
+        if let thumb = CGImageSourceCreateThumbnailAtIndex(src, 0, thumbOptions as CFDictionary) {
+            return thumb
+        }
+        return CGImageSourceCreateImageAtIndex(src, 0, nil)
+    }
+
+    private static func fetchProbeData(for url: URL, configuration: WebImagePickerConfiguration) async -> Data? {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = configuration.requestTimeout
+        if let ua = configuration.userAgent {
+            request.setValue(ua, forHTTPHeaderField: "User-Agent")
+        }
+
+        let cap = max(1024, configuration.maximumImageDownloadBytes)
+        let byteLimit = min(probeByteLimit, cap)
+        request.setValue("bytes=0-\(byteLimit - 1)", forHTTPHeaderField: "Range")
+
+        do {
+            let (data, response) = try await configuration.urlSession.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
+                return nil
+            }
+            return Data(data.prefix(byteLimit))
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerConfiguration.swift
@@ -77,6 +77,18 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     /// When using ``DiscoveredImageSort/faceCountDescending`` or ``faceCountAscending``, the maximum number of images **per page** (in discovery order) to probe and analyze with on-device Vision. Additional images keep discovery order after the sorted prefix. Use `0` to skip analysis (no face-based reordering). Default `40`.
     public var maximumFaceCountAnalysisImages: Int
 
+    /// When `true`, runs on-device text recognition (Vision) on up to ``maximumImageTextSearchImages`` discovered images so the browsing search field can match text **inside** raster images. Default `false` (privacy / performance).
+    public var isImageTextSearchEnabled: Bool
+
+    /// Upper bound on how many discovered images (in discovery order) receive OCR when ``isImageTextSearchEnabled`` is `true`. `0` skips OCR. Default `32`.
+    public var maximumImageTextSearchImages: Int
+
+    /// Optional BCP-47 language identifiers for ``VNRecognizeTextRequest`` (for example `"en-US"`). `nil` or empty lets Vision choose defaults.
+    public var imageTextRecognitionLanguages: [String]?
+
+    /// Parallel ranged GET + Vision requests while building the in-image text index. Default `2`.
+    public var maximumConcurrentImageTextRecognition: Int
+
     /// Session used for HTML fetches and image downloads. Defaults to `URLSession.shared`.
     public var urlSession: URLSession
 
@@ -101,6 +113,10 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
     ///   - unknownImageTypePolicy: Behavior for unknown types when an allowlist is active.
     ///   - selectionOutputMode: How ``WebImageSelection`` values are filled after download.
     ///   - maximumFaceCountAnalysisImages: Vision face-sort budget per page; `0` disables analysis.
+    ///   - isImageTextSearchEnabled: When `true`, OCR indexes a prefix of discovered images for search.
+    ///   - maximumImageTextSearchImages: Cap on OCR’d images when image text search is enabled.
+    ///   - imageTextRecognitionLanguages: Optional Vision recognition language tags.
+    ///   - maximumConcurrentImageTextRecognition: Parallelism for OCR ranged GETs + Vision.
     ///   - urlSession: Session used for fetches; defaults to `URLSession.shared`.
     public init(
         selectionLimit: Int = 1,
@@ -122,6 +138,10 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         unknownImageTypePolicy: WebImageUnknownTypePolicy = .allow,
         selectionOutputMode: WebImageSelectionOutputMode = .dataOnly,
         maximumFaceCountAnalysisImages: Int = 40,
+        isImageTextSearchEnabled: Bool = false,
+        maximumImageTextSearchImages: Int = 32,
+        imageTextRecognitionLanguages: [String]? = nil,
+        maximumConcurrentImageTextRecognition: Int = 2,
         urlSession: URLSession = .shared
     ) {
         self.selectionLimit = max(1, selectionLimit)
@@ -143,6 +163,10 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         self.unknownImageTypePolicy = unknownImageTypePolicy
         self.selectionOutputMode = selectionOutputMode
         self.maximumFaceCountAnalysisImages = max(0, maximumFaceCountAnalysisImages)
+        self.isImageTextSearchEnabled = isImageTextSearchEnabled
+        self.maximumImageTextSearchImages = max(0, maximumImageTextSearchImages)
+        self.imageTextRecognitionLanguages = imageTextRecognitionLanguages.flatMap { $0.isEmpty ? nil : $0 }
+        self.maximumConcurrentImageTextRecognition = max(1, maximumConcurrentImageTextRecognition)
         self.urlSession = urlSession
     }
 
@@ -168,6 +192,10 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
             && lhs.unknownImageTypePolicy == rhs.unknownImageTypePolicy
             && lhs.selectionOutputMode == rhs.selectionOutputMode
             && lhs.maximumFaceCountAnalysisImages == rhs.maximumFaceCountAnalysisImages
+            && lhs.isImageTextSearchEnabled == rhs.isImageTextSearchEnabled
+            && lhs.maximumImageTextSearchImages == rhs.maximumImageTextSearchImages
+            && lhs.imageTextRecognitionLanguages == rhs.imageTextRecognitionLanguages
+            && lhs.maximumConcurrentImageTextRecognition == rhs.maximumConcurrentImageTextRecognition
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -190,6 +218,10 @@ public struct WebImagePickerConfiguration: Sendable, Hashable {
         hasher.combine(unknownImageTypePolicy)
         hasher.combine(selectionOutputMode)
         hasher.combine(maximumFaceCountAnalysisImages)
+        hasher.combine(isImageTextSearchEnabled)
+        hasher.combine(maximumImageTextSearchImages)
+        hasher.combine(imageTextRecognitionLanguages)
+        hasher.combine(maximumConcurrentImageTextRecognition)
     }
 
     private static func hashCGSizeOptional(_ size: CGSize?, into hasher: inout Hasher) {

--- a/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
+++ b/Packages/WebImagePicker/Sources/WebImagePicker/WebImagePickerViewModel.swift
@@ -27,6 +27,9 @@ final class WebImagePickerViewModel {
     var aggregationNotice: String?
     var isConfirming: Bool = false
 
+    /// Recognized in-image text per ``DiscoveredImage/sourceURL`` when ``WebImagePickerConfiguration/isImageTextSearchEnabled`` is `true`. Filled asynchronously after load.
+    internal private(set) var imageRecognizedTextByURL: [URL: String] = [:]
+
     enum Phase: Equatable {
         case urlEntry
         case loadingPage
@@ -35,6 +38,7 @@ final class WebImagePickerViewModel {
 
     let configuration: WebImagePickerConfiguration
     private let extractor: any PageImageExtractor
+    private var imageTextSearchTask: Task<Void, Never>?
 
     init(configuration: WebImagePickerConfiguration) {
         self.configuration = configuration
@@ -57,10 +61,12 @@ final class WebImagePickerViewModel {
 
     /// Images shown in the grid after applying ``imageMetadataSearchQuery``.
     var discoveredForDisplay: [DiscoveredImage] {
-        DiscoveredImageMetadataSearch.filteredDiscoveries(
+        let ocr = configuration.isImageTextSearchEnabled ? imageRecognizedTextByURL : nil
+        return DiscoveredImageMetadataSearch.filteredDiscoveries(
             discovered,
             rawQuery: imageMetadataSearchQuery,
-            configuration: configuration
+            configuration: configuration,
+            recognizedTextByURL: ocr
         )
     }
 
@@ -111,6 +117,7 @@ final class WebImagePickerViewModel {
         imageMetadataSearchQuery = ""
         selectedURLs = []
         phase = .browsing
+        scheduleImageTextSearchIfNeeded()
         if !merge.failedPageURLs.isEmpty {
             let format = String(
                 localized: String.LocalizationValue("webimage.partialPageFailuresFormat"),
@@ -212,12 +219,35 @@ final class WebImagePickerViewModel {
     }
 
     func beginChangingURL() {
+        cancelImageTextSearchTask()
+        imageRecognizedTextByURL = [:]
         phase = .urlEntry
         discovered = []
         imageMetadataSearchQuery = ""
         selectedURLs = []
         errorMessage = nil
         aggregationNotice = nil
+    }
+
+    private func cancelImageTextSearchTask() {
+        imageTextSearchTask?.cancel()
+        imageTextSearchTask = nil
+    }
+
+    private func scheduleImageTextSearchIfNeeded() {
+        cancelImageTextSearchTask()
+        imageRecognizedTextByURL = [:]
+        guard configuration.isImageTextSearchEnabled else { return }
+        let limit = configuration.maximumImageTextSearchImages
+        guard limit > 0 else { return }
+        let urls = Array(discovered.prefix(limit).map(\.sourceURL))
+        let cfg = configuration
+        imageTextSearchTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let index = await DiscoveredImageTextRecognition.buildIndex(urls: urls, configuration: cfg)
+            guard !Task.isCancelled else { return }
+            self.imageRecognizedTextByURL = index
+        }
     }
 
     static func userMessage(for error: Error) -> String {

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageMetadataSearchTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageMetadataSearchTests.swift
@@ -99,4 +99,13 @@ final class DiscoveredImageMetadataSearchTests: XCTestCase {
         let out = DiscoveredImageMetadataSearch.filteredDiscoveries([png], rawQuery: "format:notarealext")
         XCTAssertTrue(out.isEmpty)
     }
+
+    func testRecognizedImageTextParticipatesInSearch() {
+        let url = URL(string: "https://x.com/photo.jpg")!
+        let img = DiscoveredImage(sourceURL: url, accessibilityLabel: nil, title: nil)
+        let ocr: [URL: String] = [url: "Quarterly Report 2024"]
+        XCTAssertTrue(DiscoveredImageMetadataSearch.matches(img, rawQuery: "quarterly", recognizedTextByURL: ocr))
+        let out = DiscoveredImageMetadataSearch.filteredDiscoveries([img], rawQuery: "2024", recognizedTextByURL: ocr)
+        XCTAssertEqual(out.count, 1)
+    }
 }

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageTextRecognitionTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/DiscoveredImageTextRecognitionTests.swift
@@ -1,0 +1,40 @@
+#if os(macOS)
+import AppKit
+#endif
+import XCTest
+@testable import WebImagePicker
+
+final class DiscoveredImageTextRecognitionTests: XCTestCase {
+    func testRecognizedTextFromSyntheticPNG() throws {
+        #if os(macOS)
+        let data = try XCTUnwrap(Self.makePNGWithBoldText("OCRFINDME"))
+        let text = DiscoveredImageTextRecognition.recognizedText(fromImageData: data, languages: ["en-US"])
+        XCTAssertNotNil(text, "Vision OCR returned nil for synthetic PNG")
+        XCTAssertTrue(text!.localizedCaseInsensitiveContains("OCRFINDME"), "Vision OCR text was: \(text ?? "nil")")
+        #else
+        throw XCTSkip("Synthetic PNG fixture is macOS-only (AppKit).")
+        #endif
+    }
+}
+
+#if os(macOS)
+private extension DiscoveredImageTextRecognitionTests {
+    static func makePNGWithBoldText(_ string: String) -> Data? {
+        let size = NSSize(width: 480, height: 120)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSBezierPath.fill(NSRect(origin: .zero, size: size))
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.boldSystemFont(ofSize: 48),
+            .foregroundColor: NSColor.black,
+        ]
+        (string as NSString).draw(at: NSPoint(x: 20, y: 36), withAttributes: attrs)
+        image.unlockFocus()
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else { return nil }
+        return png
+    }
+}
+#endif

--- a/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
+++ b/Packages/WebImagePicker/Tests/WebImagePickerTests/WebImagePickerConfigurationTests.swift
@@ -155,6 +155,31 @@ final class WebImagePickerConfigurationTests: XCTestCase {
         XCTAssertNotEqual(a, b)
     }
 
+    func testDefaultImageTextSearchDisabled() {
+        XCTAssertFalse(WebImagePickerConfiguration.default.isImageTextSearchEnabled)
+        XCTAssertEqual(WebImagePickerConfiguration.default.maximumImageTextSearchImages, 32)
+        XCTAssertNil(WebImagePickerConfiguration.default.imageTextRecognitionLanguages)
+        XCTAssertEqual(WebImagePickerConfiguration.default.maximumConcurrentImageTextRecognition, 2)
+    }
+
+    func testMaximumImageTextSearchImagesClampedNonNegative() {
+        XCTAssertEqual(WebImagePickerConfiguration(maximumImageTextSearchImages: -3).maximumImageTextSearchImages, 0)
+    }
+
+    func testMaximumConcurrentImageTextRecognitionClampedToAtLeastOne() {
+        XCTAssertEqual(WebImagePickerConfiguration(maximumConcurrentImageTextRecognition: 0).maximumConcurrentImageTextRecognition, 1)
+    }
+
+    func testEmptyImageTextRecognitionLanguagesNormalizedToNil() {
+        XCTAssertNil(WebImagePickerConfiguration(imageTextRecognitionLanguages: []).imageTextRecognitionLanguages)
+    }
+
+    func testImageTextSearchFlagsAffectEquality() {
+        let a = WebImagePickerConfiguration(isImageTextSearchEnabled: true)
+        let b = WebImagePickerConfiguration(isImageTextSearchEnabled: false)
+        XCTAssertNotEqual(a, b)
+    }
+
     func testSimilarImageDeduplicationAffectsEquality() {
         let a = WebImagePickerConfiguration(similarImageDeduplication: .disabled)
         let b = WebImagePickerConfiguration(similarImageDeduplication: .normalizedResourceURL)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ var config = WebImagePickerConfiguration(
 
 For example, **`selectionLimit: 10`** allows up to ten images before the user taps Done.
 
+**In-image text search (Vision OCR)** — Off by default. Set **`isImageTextSearchEnabled`** to `true` to run **`VNRecognizeTextRequest`** on the first **`maximumImageTextSearchImages`** discovered URLs (ranged GET + thumbnail decode, similar to face-count analysis). Recognized text is cached per URL for the browsing session and participates in the same search field as alt text, `title`, and the image address. Use **`imageTextRecognitionLanguages`** (BCP‑47 tags, e.g. `"en-US"`) when you want explicit languages; **`maximumConcurrentImageTextRecognition`** bounds parallel probes (default `2`). This sends additional image-byte requests and performs on-device OCR — review privacy labels and performance for your app.
+
 **`maximumDiscoveredImagesPerPage`** — Optional cap on how many image candidates are kept from **each** loaded page after discovery (default `nil` = unlimited). Truncation keeps the first N URLs in extractor order. For **`.staticHTML`**, that order is: `<img>` / `srcset` and `<picture>` sources in DOM order, then Open Graph and Twitter image tags, then `url(...)` values from inline `style` attributes and `<style>` blocks. In **multi-URL** mode (primary field + `additionalPageURLs` + extra rows), the limit applies **per page** before results are merged and de-duplicated across pages.
 
 ### Localization
@@ -183,7 +185,9 @@ swift build
 swift test
 ```
 
-Unit tests cover HTML parsing and URL resolution using bundled fixtures (no network in CI by default).
+Unit tests cover HTML parsing and URL resolution using bundled fixtures (no network in CI by default). OCR is covered with a **synthetic PNG** and Vision; if a future OS/SDK change makes recognition flaky, re-run locally or adjust the fixture.
+
+**Manual QA (in-image search):** Enable **`isImageTextSearchEnabled`** in a debug build, load a page with images that contain obvious text, wait for thumbnails, type a substring that appears only inside the bitmap (not in the URL/alt), and confirm the grid filters as expected. Change URL to confirm the OCR task cancels and the index clears.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `DiscoveredImageTextRecognition` (ranged GET + thumbnail decode + `VNRecognizeTextRequest`) with chunked concurrency, `Task.checkCancellation` between batches, and URL-keyed index merge.
- New `WebImagePickerConfiguration` options: `isImageTextSearchEnabled` (default off), `maximumImageTextSearchImages`, `imageTextRecognitionLanguages`, `maximumConcurrentImageTextRecognition`.
- `WebImagePickerViewModel` runs indexing after browse load, cancels on URL change; `DiscoveredImageMetadataSearch` matches OCR blobs when enabled.
- README privacy/performance + manual QA; macOS fixture test for Vision (iOS skips).

## Test plan
- `cd Packages/WebImagePicker && swift test`
- 128 tests passed.

Closes #47

Made with [Cursor](https://cursor.com)