### PR TITLE
Fix #49: categorized demo sample URLs (menu / list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Use it when you want users to pull images from the web without leaving your app 
 5. **Signing** — if Xcode complains, select the app target → **Signing & Capabilities** → enable **Automatically manage signing** and pick a **Team** (Personal Team is fine for local runs). See **[CONTRIBUTING.md](CONTRIBUTING.md#code-signing-demo-target)**—do not commit team IDs.
 6. **Run** — **Product → Run** (⌘R). Tap **Pick from web** and type a URL, or open **Try a sample page** for a pre-filled HTTPS URL, then **Load page**, select thumbnails, and **Done**.
 
+### Demo sample pages
+
+Curated URLs and scenario notes are defined in **[`SwiftUI Web Image Picker/DemoSampleCatalog.swift`](SwiftUI%20Web%20Image%20Picker/DemoSampleCatalog.swift)** (hardcoded list only; no network fetch to build the menu). On **macOS**, **Try a sample page** is a **nested menu** by category; on **iPhone / iPad / visionOS**, the same entries appear in a **grouped list** with short descriptions. Categories include encyclopedia-style articles, retail and news homepages, a thumbnail-heavy gallery page, **SVG-heavy** documentation, and **Unsplash** with **`.webView`** extraction for a JavaScript-rendered gallery.
+
 When you are ready to integrate, follow **[Installation](#installation)** and **[Quick start](#quick-start)** below.
 
 ## Features

--- a/SwiftUI Web Image Picker/ContentView.swift
+++ b/SwiftUI Web Image Picker/ContentView.swift
@@ -4,7 +4,7 @@
 //
 //  Demo integration: present `WebImagePicker` with `.webImagePicker(isPresented:configuration:onPick:)`.
 //  Each presentation uses a fresh `WebImagePickerConfiguration` so `initialURLString` can pre-fill
-//  the URL field when launching from a sample page.
+//  the URL field when launching from a sample page (see `DemoSampleCatalog`).
 //
 
 import SwiftUI
@@ -15,36 +15,19 @@ struct ContentView: View {
     @State private var selections: [WebImageSelection] = []
     @State private var pickerConfiguration = WebImagePickerConfiguration()
 
-    /// Static HTML–heavy pages that work well with default `.staticHTML` extraction.
-    private enum SamplePage: String, CaseIterable {
-        case wikipediaCat = "https://en.wikipedia.org/wiki/Cat"
-        case apple = "https://www.apple.com/"
-        case mozilla = "https://www.mozilla.org/"
-
-        var menuTitle: String {
-            switch self {
-            case .wikipediaCat: "Wikipedia — Cat"
-            case .apple: "Apple.com"
-            case .mozilla: "Mozilla.org"
-            }
-        }
-    }
-
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
                 Button("Pick from web") {
-                    presentPicker(initialURL: nil)
+                    presentPickerBlank()
                 }
                 .buttonStyle(.borderedProminent)
 
-                Menu("Try a sample page") {
-                    ForEach(SamplePage.allCases, id: \.self) { page in
-                        Button(page.menuTitle) {
-                            presentPicker(initialURL: page.rawValue)
-                        }
-                    }
-                }
+#if os(macOS)
+                samplePagesMenuMacOS
+#else
+                samplePagesListNonMac
+#endif
 
                 if selections.isEmpty {
                     Text("No images selected yet.")
@@ -71,8 +54,67 @@ struct ContentView: View {
         }
     }
 
-    private func presentPicker(initialURL: String?) {
-        pickerConfiguration = WebImagePickerConfiguration(initialURLString: initialURL)
+#if os(macOS)
+    private var samplePagesMenuMacOS: some View {
+        Menu("Try a sample page") {
+            ForEach(DemoSampleCategory.allCases) { category in
+                Menu(category.rawValue) {
+                    ForEach(DemoSampleCatalog.samples(in: category)) { sample in
+                        Button(sample.title) {
+                            presentPicker(sample: sample)
+                        }
+                        .help(sample.detail)
+                    }
+                }
+            }
+        }
+    }
+#else
+    private var samplePagesListNonMac: some View {
+        List {
+            ForEach(DemoSampleCategory.allCases) { category in
+                Section(category.rawValue) {
+                    ForEach(DemoSampleCatalog.samples(in: category)) { sample in
+                        Button {
+                            presentPicker(sample: sample)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text(sample.title)
+                                    if sample.extractionMode == .webView {
+                                        Text("WebView")
+                                            .font(.caption2)
+                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 2)
+                                            .background(.secondary.opacity(0.2))
+                                            .clipShape(Capsule())
+                                    }
+                                }
+                                Text(sample.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .frame(minHeight: 220, maxHeight: 360)
+    }
+#endif
+
+    private func presentPickerBlank() {
+        pickerConfiguration = WebImagePickerConfiguration()
+        showPicker = true
+    }
+
+    private func presentPicker(sample: DemoSample) {
+        var config = WebImagePickerConfiguration(initialURLString: sample.urlString)
+        config.extractionMode = sample.extractionMode
+        pickerConfiguration = config
         showPicker = true
     }
 

--- a/SwiftUI Web Image Picker/DemoSampleCatalog.swift
+++ b/SwiftUI Web Image Picker/DemoSampleCatalog.swift
@@ -1,0 +1,90 @@
+//
+//  DemoSampleCatalog.swift
+//  SwiftUI Web Image Picker
+//
+//  Curated HTTPS URLs for the demo app only (hardcoded; no network fetch for the menu).
+//
+
+import Foundation
+import WebImagePicker
+
+enum DemoSampleCategory: String, CaseIterable, Identifiable {
+    var id: String { rawValue }
+
+    case encyclopedia = "Encyclopedia"
+    case retail = "Retail & marketing"
+    case news = "News"
+    case community = "Community"
+    case gallery = "Galleries"
+    case vector = "SVG-heavy pages"
+    case javaScript = "JavaScript (WebView)"
+}
+
+struct DemoSample: Identifiable {
+    let id: String
+    let category: DemoSampleCategory
+    let title: String
+    /// Short scenario blurb for the list UI and menu tooltips.
+    let detail: String
+    let urlString: String
+    var extractionMode: WebImageExtractionMode = .staticHTML
+}
+
+enum DemoSampleCatalog {
+    static let all: [DemoSample] = [
+        DemoSample(
+            id: "wiki-cat",
+            category: .encyclopedia,
+            title: "Wikipedia — Cat",
+            detail: "Article photos, srcset, and many inline images (static HTML).",
+            urlString: "https://en.wikipedia.org/wiki/Cat"
+        ),
+        DemoSample(
+            id: "apple",
+            category: .retail,
+            title: "Apple",
+            detail: "Marketing hero art and product imagery.",
+            urlString: "https://www.apple.com/"
+        ),
+        DemoSample(
+            id: "bbc",
+            category: .news,
+            title: "BBC",
+            detail: "News layout with lead imagery.",
+            urlString: "https://www.bbc.com/"
+        ),
+        DemoSample(
+            id: "mozilla",
+            category: .community,
+            title: "Mozilla",
+            detail: "Non-profit homepage with mixed imagery.",
+            urlString: "https://www.mozilla.org/"
+        ),
+        DemoSample(
+            id: "commons",
+            category: .gallery,
+            title: "Wikimedia Commons",
+            detail: "Thumbnail-heavy main page and gallery patterns.",
+            urlString: "https://commons.wikimedia.org/wiki/Main_Page"
+        ),
+        DemoSample(
+            id: "mdn-svg",
+            category: .vector,
+            title: "MDN — SVG tutorial",
+            detail: "Documentation with SVG examples embedded in HTML.",
+            urlString: "https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Getting_Started"
+        ),
+        DemoSample(
+            id: "unsplash-webview",
+            category: .javaScript,
+            title: "Unsplash (WebView)",
+            detail: "Client-rendered gallery; demo uses `.webView` extraction.",
+            urlString: "https://unsplash.com/",
+            extractionMode: .webView
+        ),
+    ]
+
+    static func samples(in category: DemoSampleCategory) -> [DemoSample] {
+        all.filter { $0.category == category }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DemoSampleCatalog.swift` with hardcoded HTTPS samples grouped by scenario (encyclopedia, retail, news, community, gallery, SVG, JavaScript/WebView).
- **macOS:** nested **Menu** by category with `.help` tooltips; **iOS / visionOS:** grouped **List** with descriptions and a **WebView** badge for the Unsplash entry.
- Unsplash uses `.webView` extraction; README **Demo sample pages** links to the catalog file.

## Test plan
- `cd Packages/WebImagePicker && swift test`
- 138 tests passed.

Closes #49

Made with [Cursor](https://cursor.com)